### PR TITLE
feat(ui): PC 沉浸全屏、浮窗恢复与蓝牙键盘字母输入

### DIFF
--- a/AppScope/app.json5
+++ b/AppScope/app.json5
@@ -2,8 +2,8 @@
   "app": {
     "bundleName": "com.vintage.pomelopro",
     "vendor": "example",
-    "versionCode": 1002007,
-    "versionName": "1.2.7",
+    "versionCode": 1002008,
+    "versionName": "1.2.8",
     "icon": "$media:layered_image",
     "label": "$string:app_name"
   }

--- a/entry/src/main/ets/common/DeviceCapabilityPolicy.ets
+++ b/entry/src/main/ets/common/DeviceCapabilityPolicy.ets
@@ -41,6 +41,14 @@ export class DeviceCapabilityPolicy {
     });
   }
 
+  static applyPortraitOrientation(target: window.Window, tag: string): Promise<void> {
+    return target.setPreferredOrientation(window.Orientation.PORTRAIT).then(() => {
+      hilog.info(DOMAIN, tag, 'Portrait orientation applied');
+    }).catch((error: Error) => {
+      hilog.warn(DOMAIN, tag, 'Portrait orientation unavailable: %{public}s', JSON.stringify(error));
+    });
+  }
+
   static applyDesktopOrientation(target: window.Window, setting: ScreenOrientationSetting, tag: string): Promise<void> {
     let orientation: window.Orientation = window.Orientation.AUTO_ROTATION_LANDSCAPE_RESTRICTED;
     if (setting === ScreenOrientationSetting.LANDSCAPE) {
@@ -53,5 +61,30 @@ export class DeviceCapabilityPolicy {
     }).catch((error: Error) => {
       hilog.warn(DOMAIN, tag, 'Desktop orientation unavailable: %{public}s', JSON.stringify(error));
     });
+  }
+
+  /** Wait until windowRect matches the requested portrait/landscape side. */
+  static async waitForRequestedOrientation(target: window.Window, setting: ScreenOrientationSetting,
+    tag: string): Promise<void> {
+    const needLandscape = setting !== ScreenOrientationSetting.PORTRAIT;
+    for (let attempt = 0; attempt < 16; attempt++) {
+      try {
+        const rect = target.getWindowProperties().windowRect;
+        if (rect.width > 0 && rect.height > 0 &&
+          (needLandscape ? rect.width >= rect.height : rect.height >= rect.width)) {
+          hilog.info(DOMAIN, tag, 'final window rect=%{public}dx%{public}d orientation=%{public}s',
+            rect.width, rect.height, setting);
+          return;
+        }
+      } catch (_) {
+      }
+      await new Promise<void>((resolve: () => void) => setTimeout(resolve, 100));
+    }
+    try {
+      const rect = target.getWindowProperties().windowRect;
+      hilog.warn(DOMAIN, tag, 'orientation settle timeout rect=%{public}dx%{public}d requested=%{public}s',
+        rect.width, rect.height, setting);
+    } catch (_) {
+    }
   }
 }

--- a/entry/src/main/ets/common/StatusOnlyImmersiveShell.ets
+++ b/entry/src/main/ets/common/StatusOnlyImmersiveShell.ets
@@ -9,6 +9,7 @@ export const HDS_MINI_TITLE_HEIGHT_VP: number = 56;
 const MANAGED_HDS_MINI_TITLE_HEIGHT_VP: number = 40;
 const STATUS_ONLY_SYSTEM_BARS: Array<'status' | 'navigation'> = ['status'];
 const STATUS_ONLY_SYSTEM_BARS_KEY: string = STATUS_ONLY_SYSTEM_BARS.join(',');
+const DESKTOP_HIDDEN_BARS_KEY: string = 'desktop-hidden';
 
 interface WindowShellState {
   immersive: boolean;
@@ -75,6 +76,38 @@ export async function applyStatusOnlyImmersiveShell(pageWindow: window.Window): 
   }
   windowShellStateCache.set(properties.id,
     { immersive: true, systemBarsKey: STATUS_ONLY_SYSTEM_BARS_KEY });
+}
+
+/**
+ * Wine 桌面全屏壳：藏系统标题/状态栏/导航条，避免库页 status-only 壳把
+ * 状态栏留在桌面上。写入独立 cache key，缩回库页时 applyStatusOnlyImmersiveShell
+ * 才能发现契约变了并真正恢复。
+ */
+export async function applyDesktopFullscreenShell(pageWindow: window.Window): Promise<void> {
+  try {
+    await pageWindow.setWindowDecorVisible(false);
+  } catch (_) {
+  }
+  try {
+    await pageWindow.setWindowLayoutFullScreen(true);
+  } catch (_) {
+  }
+  try {
+    await Promise.all([
+      pageWindow.setSpecificSystemBarEnabled('status', false),
+      pageWindow.setSpecificSystemBarEnabled('navigationIndicator', false)
+    ]);
+  } catch (_) {
+  }
+  try {
+    await pageWindow.setWindowBackgroundColor('#000000');
+  } catch (_) {
+  }
+  try {
+    windowShellStateCache.set(pageWindow.getWindowProperties().id,
+      { immersive: true, systemBarsKey: DESKTOP_HIDDEN_BARS_KEY });
+  } catch (_) {
+  }
 }
 
 /**

--- a/entry/src/main/ets/components/DesktopLayer.ets
+++ b/entry/src/main/ets/components/DesktopLayer.ets
@@ -111,6 +111,9 @@ class DesktopController extends XComponentController {
 export struct DesktopLayer {
   @StorageLink('desktopToplevelId') @Watch('onDesktopToplevelChanged') private desktopToplevelId: number = 0;
   @StorageLink('desktopWindowMode') @Watch('onDesktopWindowModeChanged') private desktopWindowMode: string = '';
+  // overlay 关掉宿主 IME 后跨窗口把焦点要回桌面 XComponent, 蓝牙可打印键才继续走 KeyEvent。
+  @StorageLink('wineDesktopKeyFocusToken') @Watch('onDesktopKeyFocusToken')
+    private wineDesktopKeyFocusToken: number = 0;
   @State private cornerSafeMargin: number = 0;
   // 悬浮窗态 (Index 桌面层容器处于小窗缩略显示): 桌面 XComponent 所有输入
   // 一律旁路 — 点击放大/拖动由 Index 悬浮交互层统一处理, 本组件不转发
@@ -230,6 +233,14 @@ export struct DesktopLayer {
     this.applyCornerSafeMargin();
   }
 
+  private onDesktopKeyFocusToken(): void {
+    if (this.floating || this.wineDesktopKeyFocusToken <= 0) return;
+    try {
+      this.getUIContext().getFocusController().requestFocus('wine_desktop_xc');
+    } catch (_) {
+    }
+  }
+
   /** 切边模式: XComponent 四周让出圆角避让边距 (黑色), 全屏模式无内缩。 */
   private applyCornerSafeMargin(): void {
     // 悬浮窗态 (Index 小浮窗): 无需圆角避让, XComponent 全客户区铺满
@@ -300,7 +311,10 @@ export struct DesktopLayer {
         id: 'wine_desktop_xc',
         type: XComponentType.SURFACE,
         controller: this.controller
-      }).width('100%').height('100%').backgroundColor('#000').focusable(false)
+      }).width('100%').height('100%').backgroundColor('#000')
+        .focusable(true)
+        .focusOnTouch(true)
+        .defaultFocus(true)
 
       // ── 触控处理: 单指→左键/右键/拖拽, 双指→滚轮 ──
       .onTouch((ev: TouchEvent) => {
@@ -613,6 +627,7 @@ export struct DesktopLayer {
         if (vert !== 0) testNapi.sendScrollEvent(tl, 0, vert, step, wpx, wpy);
         if (horiz !== 0) testNapi.sendScrollEvent(tl, 1, horiz, step, wpx, wpy);
       })
+      .onKeyEvent((ev: KeyEvent): void => this.handleHardwareKey(ev))
 
       WineEngineBlockingOverlay()
     }
@@ -624,9 +639,5 @@ export struct DesktopLayer {
       bottom: 0
     })
     .id('wine-desktop-input-root')
-    .focusable(true)
-    .focusOnTouch(true)
-    .defaultFocus(true)
-    .onKeyEvent((ev: KeyEvent): void => this.handleHardwareKey(ev))
   }
 }

--- a/entry/src/main/ets/components/DesktopLayer.ets
+++ b/entry/src/main/ets/components/DesktopLayer.ets
@@ -40,15 +40,11 @@ class DesktopController extends XComponentController {
     if (rootId > 0) {
       try {
         testNapi.resizeRenderer(rootId, rect.surfaceWidth, rect.surfaceHeight);
-        // 悬浮窗态 (Index 小窗缩略): 跳过 root resize — 桌面分辨率保持全屏,
-        // 缩略显示靠 renderer letterbox (ComputeFitRect) 等比缩放。若把
-        // XComponent 小窗尺寸同步给 Wine 桌面, 桌面分辨率被改成小窗尺寸 →
-        // explorer 布局重排 → 全屏态时任务栏/开始菜单缺失或错位。
-        // 对齐 main_ui DesktopLayer desktopLauncherVisible 门控语义。
-        // 仅浮窗模式 (Index 承载) 生效; 非浮窗模式 (DesktopAbility 承载) 正常 resize。
-        if (AppSettingsStore.getInstance().getGlobalSettings().desktopWindowMode === DesktopWindowMode.FLOATING &&
-          WineWindowManager.getInstance().desktopLauncherVisible) {
-          hilog.info(DOMAIN, 'LIFE', '[XComp] launcher-visible: skip root resize, letterbox full desktop');
+        // 浮窗模式: 桌面分辨率由 prepareOutputForOrientation 设定, XComponent
+        // 只做 letterbox 显示口。动画中/缩略态/全屏态都不要 syncOutputSize,
+        // 否则 explorer 会再提交 desktop-shell。
+        if (AppSettingsStore.getInstance().getGlobalSettings().desktopWindowMode === DesktopWindowMode.FLOATING) {
+          hilog.info(DOMAIN, 'LIFE', '[XComp] floating: skip root resize, letterbox full desktop');
           return;
         }
         const s = WineWindowManager.getInstance().getEffectiveScale();

--- a/entry/src/main/ets/components/FileBrowserView.ets
+++ b/entry/src/main/ets/components/FileBrowserView.ets
@@ -35,10 +35,13 @@ interface DriveRoot {
 
 @Component
 export struct FileBrowserView {
+  @Prop topInsetVp: number = 0;
+  @Prop bottomInsetVp: number = 0;
   @State engineState: EngineState = EngineState.STOPPED;
   @State curDir: string = DRIVE_C;
   @State entries: FileEntry[] = [];
   @State atRootList: boolean = true;
+  @State private viewW: number = 0;
   private iconFail: Set<string> = new Set<string>();
 
   private onEngine = (state: EngineState, _message: string): void => {
@@ -53,6 +56,10 @@ export struct FileBrowserView {
 
   aboutToDisappear(): void {
     WineEngineService.getInstance().unsubscribe(this.onEngine);
+  }
+
+  private compactRows(): boolean {
+    return this.viewW > 0 && this.viewW < 560;
   }
 
   private zRoot(): string {
@@ -309,7 +316,8 @@ export struct FileBrowserView {
       if (this.rowKindOf(entry) === 'exe' && entry.icon) {
         Image(`file://${entry.icon}`)
           .width(26).height(26)
-          .margin({ right: 2 })
+          .margin({ right: 8 })
+          .objectFit(ImageFit.Contain)
       } else {
         SymbolGlyph(this.rowKindOf(entry) === 'dir' ? $r('sys.symbol.folder_fill') :
           this.rowKindOf(entry) === 'exe' ? $r('sys.symbol.square_grid_2x2') : $r('sys.symbol.doc'))
@@ -317,23 +325,31 @@ export struct FileBrowserView {
           .fontColor([this.rowKindOf(entry) === 'dir' ? $r('app.color.accent') :
             this.rowKindOf(entry) === 'exe' ? $r('app.color.accent') : $r('app.color.text_secondary')])
           .width(28)
+          .margin({ right: 8 })
       }
       Text(entry.name)
+        .fontSize(14)
         .fontColor(this.rowKindOf(entry) === 'other' ? $r('app.color.text_secondary') : $r('app.color.text_primary'))
         .layoutWeight(1)
         .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
-      Text(this.rowKindOf(entry) === 'dir' ? '—' : this.fmtSize(entry.size))
-        .width(72).fontSize(11)
-        .fontColor($r('app.color.text_secondary'))
-        .textAlign(TextAlign.End).maxLines(1)
-      Text(this.fmtTime(entry.mtime))
-        .width(126).fontSize(11)
-        .fontColor($r('app.color.text_secondary'))
-        .textAlign(TextAlign.End).maxLines(1)
+      if (!this.compactRows()) {
+        Text(this.rowKindOf(entry) === 'dir' ? '—' : this.fmtSize(entry.size))
+          .width(72).fontSize(11)
+          .fontColor($r('app.color.text_secondary'))
+          .textAlign(TextAlign.End).maxLines(1)
+        Text(this.fmtTime(entry.mtime))
+          .width(126).fontSize(11)
+          .fontColor($r('app.color.text_secondary'))
+          .textAlign(TextAlign.End).maxLines(1)
+      }
       Row() {
         if (this.rowKindOf(entry) === 'exe') {
           Button('启动')
             .height(32)
+            .padding({ left: 8, right: 8 })
+            .fontSize(12)
+            .fontColor($r('app.color.text_primary'))
+            .backgroundColor($r('app.color.selected_background'))
             .onClick(() => this.launchExe(this.fullPath(entry.name)))
         } else if (this.rowKindOf(entry) === 'dir') {
           SymbolGlyph($r('sys.symbol.chevron_right'))
@@ -341,8 +357,8 @@ export struct FileBrowserView {
             .fontColor([$r('app.color.text_secondary')])
         }
       }
-      .width(88)
-      .margin({ left: 14 })
+      .width(this.compactRows() ? 64 : 88)
+      .margin({ left: this.compactRows() ? 6 : 14 })
       .justifyContent(FlexAlign.End)
       .alignItems(VerticalAlign.Center)
     }
@@ -381,20 +397,26 @@ export struct FileBrowserView {
 
   build() {
     Column() {
-      Row() {
+      Row({ space: 8 }) {
         if (!this.atRootList) {
-          Button('← 上级目录')
-            .height(32)
-            .backgroundColor($r('app.color.search_background'))
-            .onClick((): void => { this.goUp(); })
+          Button({ type: ButtonType.Circle }) {
+            SymbolGlyph($r('sys.symbol.chevron_up'))
+              .fontSize(18)
+              .fontColor([$r('app.color.text_primary')])
+          }
+          .width(36).height(36)
+          .backgroundColor($r('app.color.search_background'))
+          .onClick((): void => { this.goUp(); })
         }
         Text(this.displayPath())
+          .fontSize(14)
           .fontColor($r('app.color.text_secondary'))
-          .height(32)
-          .margin({ left: 10 }).layoutWeight(1)
+          .height(36)
+          .layoutWeight(1)
           .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
       }
-      .width('100%').padding({ left: 14, right: 14, top: 10, bottom: 6 })
+      .width('100%').padding({ left: 14, right: 14, top: 8, bottom: 6 })
+      .alignItems(VerticalAlign.Center)
 
       if (this.atRootList) {
         List({ space: 1 }) {
@@ -425,5 +447,9 @@ export struct FileBrowserView {
     }
     .width('100%')
     .layoutWeight(1)
+    .padding({ top: this.topInsetVp, bottom: this.bottomInsetVp })
+    .onAreaChange((_oldValue: Area, area: Area): void => {
+      this.viewW = area.width as number;
+    })
   }
 }

--- a/entry/src/main/ets/components/FileBrowserView.ets
+++ b/entry/src/main/ets/components/FileBrowserView.ets
@@ -1,0 +1,429 @@
+import { fileIo as fs } from '@kit.CoreFileKit';
+import { promptAction } from '@kit.ArkUI';
+import { hilog } from '../service/LogService';
+import { IconExtractor } from '../service/IconExtractor';
+import { AppCatalogService } from '../service/AppCatalogService';
+import { AppSettingsStore } from '../service/AppSettingsStore';
+import { LauncherAdapterRegistry } from '../service/LauncherAdapterRegistry';
+import { WineEngineService } from '../service/WineEngineService';
+import {
+  AppDescriptor,
+  AppSource,
+  EngineState,
+  LaunchKind,
+  stableAppId
+} from '../model/AppModels';
+
+const DOMAIN = 0x0000;
+const TAG = 'Files';
+const DRIVE_C = '/data/storage/el2/base/files/.wine/drive_c';
+
+interface FileEntry {
+  name: string;
+  isDir: boolean;
+  size: number;
+  mtime: number;
+  icon: string;
+}
+
+interface DriveRoot {
+  key: string;
+  label: string;
+  sub: string;
+  path: string;
+}
+
+@Component
+export struct FileBrowserView {
+  @State engineState: EngineState = EngineState.STOPPED;
+  @State curDir: string = DRIVE_C;
+  @State entries: FileEntry[] = [];
+  @State atRootList: boolean = true;
+  private iconFail: Set<string> = new Set<string>();
+
+  private onEngine = (state: EngineState, _message: string): void => {
+    this.engineState = state;
+  };
+
+  aboutToAppear(): void {
+    WineEngineService.getInstance().subscribe(this.onEngine);
+    this.engineState = WineEngineService.getInstance().getState();
+    this.backToRootList();
+  }
+
+  aboutToDisappear(): void {
+    WineEngineService.getInstance().unsubscribe(this.onEngine);
+  }
+
+  private zRoot(): string {
+    const z = AppCatalogService.getInstance().getWineHomeDirectory() ||
+      AppCatalogService.getInstance().getLibraryRoot();
+    return z.endsWith('/') ? z.substring(0, z.length - 1) : z;
+  }
+
+  private roots(): DriveRoot[] {
+    const z = this.zRoot();
+    const list: DriveRoot[] = [
+      { key: 'C', label: 'C:\\', sub: '系统目录 (Wine 容器)', path: DRIVE_C }
+    ];
+    if (z.length > 0) {
+      list.push({ key: 'Z', label: 'Z:\\', sub: '下载目录 (与系统共享)', path: z });
+    }
+    return list;
+  }
+
+  private rootOf(path: string): DriveRoot | null {
+    for (const r of this.roots()) {
+      if (path === r.path || path.startsWith(r.path + '/')) {
+        return r;
+      }
+    }
+    return null;
+  }
+
+  private backToRootList(): void {
+    this.atRootList = true;
+    this.entries = [];
+  }
+
+  private enterRoot(root: DriveRoot): void {
+    this.atRootList = false;
+    this.curDir = root.path;
+    this.listDir(root.path);
+  }
+
+  private goUp = (): void => {
+    const root = this.rootOf(this.curDir);
+    if (!root || this.curDir === root.path) {
+      this.backToRootList();
+      return;
+    }
+    const slash = this.curDir.lastIndexOf('/');
+    const parent = slash > 0 ? this.curDir.substring(0, slash) : root.path;
+    this.curDir = parent.length > 0 ? parent : root.path;
+    this.listDir(this.curDir);
+  };
+
+  private fullPath(name: string): string {
+    return this.curDir + '/' + name;
+  }
+
+  private isExe(name: string): boolean {
+    const lower = name.toLowerCase();
+    return lower.endsWith('.exe') || lower.endsWith('.bat') || lower.endsWith('.cmd');
+  }
+
+  private rowKindOf(entry: FileEntry): string {
+    if (entry.isDir) {
+      return 'dir';
+    }
+    return this.isExe(entry.name) ? 'exe' : 'other';
+  }
+
+  private displayPath(): string {
+    if (this.atRootList) {
+      return '此设备';
+    }
+    const root = this.rootOf(this.curDir);
+    if (!root) {
+      return this.curDir;
+    }
+    const rest = this.curDir === root.path ? '' : this.curDir.substring(root.path.length).replace(/\//g, '\\');
+    return root.label + rest;
+  }
+
+  private fmtSize(size: number): string {
+    if (size < 0) {
+      return '—';
+    }
+    if (size < 1024) {
+      return `${size} B`;
+    }
+    const units: string[] = ['KB', 'MB', 'GB', 'TB'];
+    let v = size;
+    let u = -1;
+    while (v >= 1024 && u < units.length - 1) {
+      v /= 1024;
+      u++;
+    }
+    return `${v >= 100 ? v.toFixed(0) : v.toFixed(1)} ${units[u]}`;
+  }
+
+  private fmtTime(ms: number): string {
+    if (ms <= 0) {
+      return '';
+    }
+    const d = new Date(ms);
+    const p = (v: number): string => (v < 10 ? '0' : '') + v;
+    return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`;
+  }
+
+  private listDir(path: string): void {
+    try {
+      const names = fs.listFileSync(path);
+      const list: FileEntry[] = [];
+      for (const n of names) {
+        try {
+          const st = fs.statSync(path + '/' + n);
+          list.push({
+            name: n,
+            isDir: st.isDirectory(),
+            size: st.isDirectory() ? -1 : Number(st.size),
+            mtime: Number(st.mtime),
+            icon: ''
+          });
+        } catch (_) {
+          list.push({ name: n, isDir: false, size: -1, mtime: 0, icon: '' });
+        }
+      }
+      list.sort((a: FileEntry, b: FileEntry) => {
+        if (a.isDir && !b.isDir) {
+          return -1;
+        }
+        if (!a.isDir && b.isDir) {
+          return 1;
+        }
+        if (!a.isDir && !b.isDir) {
+          const aExe = this.isExe(a.name) ? 0 : 1;
+          const bExe = this.isExe(b.name) ? 0 : 1;
+          return aExe - bExe || a.name.localeCompare(b.name);
+        }
+        return a.name.localeCompare(b.name);
+      });
+      this.entries = list;
+      this.loadIcons();
+    } catch (e) {
+      hilog.error(DOMAIN, TAG, 'listDir fail: %{public}s err=%{public}s', path, JSON.stringify(e));
+      this.entries = [];
+    }
+  }
+
+  private async loadIcons(): Promise<void> {
+    const paths: string[] = [];
+    for (const e of this.entries) {
+      if (!e.isDir && this.isExe(e.name) && !e.icon && !this.iconFail.has(this.fullPath(e.name))) {
+        paths.push(this.fullPath(e.name));
+      }
+    }
+    const dir = this.curDir;
+    for (let i = 0; i < paths.length; i += 4) {
+      const batch = paths.slice(i, i + 4);
+      await Promise.all(batch.map(async (p: string) => {
+        const icon = await IconExtractor.getInstance().extract(p);
+        if (this.curDir !== dir) {
+          return;
+        }
+        if (!icon) {
+          this.iconFail.add(p);
+          return;
+        }
+        const name = p.substring(p.lastIndexOf('/') + 1);
+        this.entries = this.entries.map((e: FileEntry): FileEntry =>
+          e.name === name && !e.icon ?
+            { name: e.name, isDir: e.isDir, size: e.size, mtime: e.mtime, icon: icon } : e);
+      }));
+    }
+  }
+
+  private descriptorFor(path: string): AppDescriptor {
+    const slash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+    const name = slash >= 0 ? path.substring(slash + 1) : path;
+    const dir = slash >= 0 ? path.substring(0, slash) : '';
+    return {
+      id: stableAppId(AppSource.DOWNLOAD, path),
+      title: name,
+      source: AppSource.DOWNLOAD,
+      directory: dir,
+      coverPath: '',
+      available: true,
+      launchTarget: {
+        kind: LaunchKind.WINE_EXE,
+        executable: path,
+        arguments: [],
+        workingDirectory: dir
+      },
+      displayModeOverride: null
+    };
+  }
+
+  private async launchExe(path: string): Promise<void> {
+    const settings = AppSettingsStore.getInstance().getGlobalSettings();
+    const root = AppCatalogService.getInstance().getWineHomeDirectory();
+    if (!root) {
+      promptAction.showToast({ message: '下载目录尚未就绪，请先扫描 Windows 程序' });
+      return;
+    }
+    try {
+      const session = await LauncherAdapterRegistry.getInstance()
+        .launch(this.descriptorFor(path), settings, root);
+      if (!session) {
+        const msg = WineEngineService.getInstance().getMessage();
+        promptAction.showToast({
+          message: msg === 'Wine 引擎已就绪' ? '启动失败，请稍后重试' : msg
+        });
+      }
+    } catch (_) {
+      promptAction.showToast({ message: '程序启动异常，请稍后重试' });
+    }
+  }
+
+  private gamesRoot(): string {
+    return AppCatalogService.getInstance().getGamesDirectory();
+  }
+
+  private inGames(path: string): boolean {
+    const games = this.gamesRoot();
+    if (!games) {
+      return false;
+    }
+    return path === games || path.startsWith(games + '/');
+  }
+
+  private addToLibrary(path: string): void {
+    if (this.inGames(path)) {
+      promptAction.showToast({ message: '已在 Z:\\games 下，请到 Windows 程序页下拉扫描' });
+      return;
+    }
+    promptAction.showToast({ message: '请将程序放到 Download/.../games 后再扫描入库' });
+  }
+
+  @Builder
+  fileMenu(entry: FileEntry) {
+    Menu() {
+      if (this.rowKindOf(entry) === 'exe') {
+        MenuItem({ content: '启动' })
+          .onChange(() => {
+            this.launchExe(this.fullPath(entry.name));
+          })
+        MenuItem({ content: '加入应用库' })
+          .onChange(() => {
+            this.addToLibrary(this.fullPath(entry.name));
+          })
+      }
+    }
+  }
+
+  @Builder
+  fileRow(entry: FileEntry) {
+    Row() {
+      if (this.rowKindOf(entry) === 'exe' && entry.icon) {
+        Image(`file://${entry.icon}`)
+          .width(26).height(26)
+          .margin({ right: 2 })
+      } else {
+        SymbolGlyph(this.rowKindOf(entry) === 'dir' ? $r('sys.symbol.folder_fill') :
+          this.rowKindOf(entry) === 'exe' ? $r('sys.symbol.square_grid_2x2') : $r('sys.symbol.doc'))
+          .fontSize(20)
+          .fontColor([this.rowKindOf(entry) === 'dir' ? $r('app.color.accent') :
+            this.rowKindOf(entry) === 'exe' ? $r('app.color.accent') : $r('app.color.text_secondary')])
+          .width(28)
+      }
+      Text(entry.name)
+        .fontColor(this.rowKindOf(entry) === 'other' ? $r('app.color.text_secondary') : $r('app.color.text_primary'))
+        .layoutWeight(1)
+        .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
+      Text(this.rowKindOf(entry) === 'dir' ? '—' : this.fmtSize(entry.size))
+        .width(72).fontSize(11)
+        .fontColor($r('app.color.text_secondary'))
+        .textAlign(TextAlign.End).maxLines(1)
+      Text(this.fmtTime(entry.mtime))
+        .width(126).fontSize(11)
+        .fontColor($r('app.color.text_secondary'))
+        .textAlign(TextAlign.End).maxLines(1)
+      Row() {
+        if (this.rowKindOf(entry) === 'exe') {
+          Button('启动')
+            .height(32)
+            .onClick(() => this.launchExe(this.fullPath(entry.name)))
+        } else if (this.rowKindOf(entry) === 'dir') {
+          SymbolGlyph($r('sys.symbol.chevron_right'))
+            .fontSize(16)
+            .fontColor([$r('app.color.text_secondary')])
+        }
+      }
+      .width(88)
+      .margin({ left: 14 })
+      .justifyContent(FlexAlign.End)
+      .alignItems(VerticalAlign.Center)
+    }
+    .width('100%').height(44).padding({ left: 14, right: 14 })
+    .alignItems(VerticalAlign.Center)
+  }
+
+  @Builder
+  rootRow(root: DriveRoot) {
+    Row() {
+      SymbolGlyph(root.key === 'C' ? $r('sys.symbol.archivebox') : $r('sys.symbol.folder_fill'))
+        .fontSize(22)
+        .fontColor([$r('app.color.accent')])
+        .width(30)
+      Column({ space: 2 }) {
+        Text(root.label)
+          .fontColor($r('app.color.text_primary'))
+        Text(root.sub)
+          .fontSize(11)
+          .fontColor($r('app.color.text_secondary'))
+      }
+      .alignItems(HorizontalAlign.Start)
+      .layoutWeight(1)
+      .margin({ left: 6 })
+      SymbolGlyph($r('sys.symbol.chevron_right'))
+        .fontSize(16)
+        .fontColor([$r('app.color.text_secondary')])
+    }
+    .width('100%').height(56).padding({ left: 14, right: 14 })
+    .alignItems(VerticalAlign.Center)
+    .backgroundColor($r('app.color.card_background'))
+    .onClick(() => {
+      this.enterRoot(root);
+    })
+  }
+
+  build() {
+    Column() {
+      Row() {
+        if (!this.atRootList) {
+          Button('← 上级目录')
+            .height(32)
+            .backgroundColor($r('app.color.search_background'))
+            .onClick((): void => { this.goUp(); })
+        }
+        Text(this.displayPath())
+          .fontColor($r('app.color.text_secondary'))
+          .height(32)
+          .margin({ left: 10 }).layoutWeight(1)
+          .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
+      }
+      .width('100%').padding({ left: 14, right: 14, top: 10, bottom: 6 })
+
+      if (this.atRootList) {
+        List({ space: 1 }) {
+          ForEach(this.roots(), (root: DriveRoot): void => {
+            ListItem() {
+              this.rootRow(root)
+            }
+          }, (root: DriveRoot): string => root.key)
+        }
+        .width('100%').layoutWeight(1)
+      } else {
+        List({ space: 1 }) {
+          ForEach(this.entries, (entry: FileEntry): void => {
+            ListItem() {
+              this.fileRow(entry)
+            }
+            .bindContextMenu(this.fileMenu(entry), ResponseType.LongPress)
+            .onClick((): void => {
+              if (entry.isDir) {
+                this.curDir = this.fullPath(entry.name);
+                this.listDir(this.curDir);
+              }
+            })
+          }, (entry: FileEntry): string => entry.name + (entry.isDir ? '/d' : ''))
+        }
+        .width('100%').layoutWeight(1)
+      }
+    }
+    .width('100%')
+    .layoutWeight(1)
+  }
+}

--- a/entry/src/main/ets/components/VirtualInputOverlay.ets
+++ b/entry/src/main/ets/components/VirtualInputOverlay.ets
@@ -76,7 +76,8 @@ export struct VirtualInputOverlay {
   /** 触摸板箭头指针；关闭后仍移动与点击，只是不画光标。 */
   @Prop showCursor: boolean = true;
   /** 浮窗模式全屏态: 控制栏显示 home 按钮 (缩回 Index 悬浮窗)。 */
-  @StorageProp('desktopFloatingFullscreen') desktopFloatingFullscreen: boolean = false;
+  @StorageProp('desktopFloatingFullscreen') @Watch('onFloatingFullscreenChanged')
+  desktopFloatingFullscreen: boolean = false;
   /** 编辑器模式：不注入按键，元素可拖动/缩放并支持选中框。 */
   @Prop editMode: boolean = false;
   @Prop @Watch('onCrosshairStateChanged') selectedElementId: string = '';
@@ -297,33 +298,6 @@ export struct VirtualInputOverlay {
     return pressed ? WINLATOR_DARK : WINLATOR_LIGHT;
   }
 
-  private dpadArmPath(element: ControlElement, direction: string): string {
-    const w = this.elementWidth(element);
-    const h = this.elementHeight(element);
-    const inset = this.winlatorStrokeWidth() * 0.5;
-    const cx = w / 2;
-    const cy = h / 2;
-    const s = Math.min(w, h) / 14;
-    const ox = s * 2;
-    const oy = s * 3;
-    const start = s;
-    const pt = (x: number, y: number): string => x.toFixed(1) + ' ' + y.toFixed(1);
-    if (direction === 'up') {
-      return 'M ' + pt(cx, cy - start) + ' L ' + pt(cx - ox, cy - oy) + ' L ' + pt(cx - ox, inset) +
-        ' L ' + pt(cx + ox, inset) + ' L ' + pt(cx + ox, cy - oy) + ' Z';
-    }
-    if (direction === 'down') {
-      return 'M ' + pt(cx, cy + start) + ' L ' + pt(cx - ox, cy + oy) + ' L ' + pt(cx - ox, h - inset) +
-        ' L ' + pt(cx + ox, h - inset) + ' L ' + pt(cx + ox, cy + oy) + ' Z';
-    }
-    if (direction === 'left') {
-      return 'M ' + pt(cx - start, cy) + ' L ' + pt(cx - oy, cy - ox) + ' L ' + pt(inset, cy - ox) +
-        ' L ' + pt(inset, cy + ox) + ' L ' + pt(cx - oy, cy + ox) + ' Z';
-    }
-    return 'M ' + pt(cx + start, cy) + ' L ' + pt(cx + oy, cy - ox) + ' L ' + pt(w - inset, cy - ox) +
-      ' L ' + pt(w - inset, cy + ox) + ' L ' + pt(cx + oy, cy + ox) + ' Z';
-  }
-
   /** 键盘键帽文字按实际键面尺寸放大, 保证平板/手机上清晰可读。 */
   private buttonLabelFontSize(element: ControlElement): number {
     if ((element.keyWidthRatio ?? 0) > 0) {
@@ -399,6 +373,15 @@ export struct VirtualInputOverlay {
     return this.rectContains(x, y, left, top, width, height);
   }
 
+  /** 虚拟控件（含视角触摸板）在触摸板模式下仍要自己吃触摸。 */
+  private isOverlayControl(element: ControlElement): boolean {
+    return element.type === ControlElementType.BUTTON ||
+      element.type === ControlElementType.RANGE_BUTTON ||
+      element.type === ControlElementType.TRACKPAD ||
+      element.type === ControlElementType.D_PAD ||
+      element.type === ControlElementType.STICK;
+  }
+
   private elementAt(x: number, y: number): ControlElement | null {
     const elements = this.profile.elements ?? [];
     for (let index = elements.length - 1; index >= 0; index--) {
@@ -444,6 +427,7 @@ export struct VirtualInputOverlay {
       '|' + (element.heightScale ?? 1).toFixed(2) +
       '|' + (element.panelWidthRatio ?? 0).toFixed(3) +
       '|' + (element.panelHeightRatio ?? 0).toFixed(3) +
+      '|' + this.overlayW.toFixed(0) + 'x' + this.overlayH.toFixed(0) +
       '|' + (element.opacity ?? -1).toString() +
       '|' + (element.text ?? '') +
       '|' + (element.shape ?? '') +
@@ -506,7 +490,8 @@ export struct VirtualInputOverlay {
   }
 
   private stickRadius(element: ControlElement): number {
-    return this.elementBaseSize(element) * (element.scale ?? 1) / 2 - 10;
+    return Math.min(this.elementWidth(element), this.elementHeight(element)) / 2 -
+      this.winlatorStrokeWidth();
   }
 
   private stickKnobSize(element: ControlElement): number {
@@ -842,6 +827,17 @@ export struct VirtualInputOverlay {
     }
   }
 
+  private updateTrackpadThumb(element: ControlElement, x: number, y: number): void {
+    const center = this.elementCenter(element);
+    const maxX = Math.max(4, this.elementWidth(element) / 2 - 10);
+    const maxY = Math.max(4, this.elementHeight(element) / 2 - 10);
+    let dx = x - center.x;
+    let dy = y - center.y;
+    dx = Math.min(Math.max(dx, -maxX), maxX);
+    dy = Math.min(Math.max(dy, -maxY), maxY);
+    this.setStickState(element.id, dx, dy, true);
+  }
+
   private handleTrackpadElementTouch(type: TouchType, touch: TouchObject, element: ControlElement): void {
     const id = element.id;
     if (type === TouchType.Down) {
@@ -853,6 +849,7 @@ export struct VirtualInputOverlay {
         startX: Number(touch.x), startY: Number(touch.y),
         lastX: Number(touch.x), lastY: Number(touch.y), moved: false
       });
+      this.updateTrackpadThumb(element, Number(touch.x), Number(touch.y));
       return;
     }
     if (type === TouchType.Move && this.activeElementTouches.get(id) === touch.id) {
@@ -864,6 +861,7 @@ export struct VirtualInputOverlay {
       const dy = y - state.lastY;
       state.lastX = x;
       state.lastY = y;
+      this.updateTrackpadThumb(element, x, y);
       if (!state.moved && Math.abs(x - state.startX) + Math.abs(y - state.startY) >= 12) {
         state.moved = true;
       }
@@ -880,6 +878,7 @@ export struct VirtualInputOverlay {
       this.activeElementTouches.delete(id);
       this.trackpadStates.delete(id);
       this.setElementPressed(id, false);
+      this.setStickState(id, 0, 0, false);
       if (type === TouchType.Up && state && !state.moved) {
         const source = 'trackpad-tap-' + id + '-' + touch.id.toString();
         InputDispatcher.getInstance().pointerDown(source, vp2px(Number(touch.x)), vp2px(Number(touch.y)), 272);
@@ -922,22 +921,24 @@ export struct VirtualInputOverlay {
 
   // -- 触摸板模式: 虚拟光标状态机 (移植 upstream main-ui DesktopLayer.handleTouchpad) --
   private ensureScreenPx(): void {
+    if (this.overlayW > 0 && this.overlayH > 0) {
+      this.scrWPx = vp2px(this.overlayW);
+      this.scrHPx = vp2px(this.overlayH);
+      return;
+    }
     const rect = InputOverlayWindowCoordinator.getInstance().getOverlayWindowRect();
     if (rect.width > 0 && rect.height > 0) {
       this.scrWPx = rect.width;
       this.scrHPx = rect.height;
-    } else if (this.overlayW > 0 && this.overlayH > 0) {
-      this.scrWPx = vp2px(this.overlayW);
-      this.scrHPx = vp2px(this.overlayH);
-    } else {
-      try {
-        const d = display.getDefaultDisplaySync();
-        this.scrWPx = d.width;
-        this.scrHPx = d.height;
-      } catch (_) {
-        this.scrWPx = 1280;
-        this.scrHPx = 800;
-      }
+      return;
+    }
+    try {
+      const d = display.getDefaultDisplaySync();
+      this.scrWPx = d.width;
+      this.scrHPx = d.height;
+    } catch (_) {
+      this.scrWPx = 1280;
+      this.scrHPx = 800;
     }
   }
 
@@ -954,6 +955,24 @@ export struct VirtualInputOverlay {
     this.syncCursorIndicator();
   }
 
+  /** Windows 式：已在边缘且增量朝外则丢弃该轴，出界位移不累加。 */
+  private applyCursorDelta(dxPx: number, dyPx: number): void {
+    this.ensureScreenPx();
+    let dx = dxPx;
+    let dy = dyPx;
+    if (this.vcX <= 0 && dx < 0) dx = 0;
+    if (this.vcX >= this.scrWPx && dx > 0) dx = 0;
+    if (this.vcY <= 0 && dy < 0) dy = 0;
+    if (this.vcY >= this.scrHPx && dy > 0) dy = 0;
+    this.vcX = Math.min(Math.max(this.vcX + dx, 0), this.scrWPx);
+    this.vcY = Math.min(Math.max(this.vcY + dy, 0), this.scrHPx);
+    this.syncCursorIndicator();
+  }
+
+  private fallbackToplevelId(): number {
+    return InputOverlayWindowCoordinator.getInstance().getSnapshot().session.toplevelId;
+  }
+
   // 性能: 光标移动时缓存目标 toplevel, 避免每次 move 都 native 查询
   // (findToplevelAt 跨 JSI/NAPI 开销大)。仅当光标明显跨窗口时才重查。
   private cachedMoveTl: number = -1;
@@ -967,7 +986,8 @@ export struct VirtualInputOverlay {
       Math.abs(x - this.cachedMoveTlX) < 4 && Math.abs(y - this.cachedMoveTlY) < 4) {
       return this.cachedMoveTl;
     }
-    const tl = (testNapi.findToplevelAt(x, y) as number) ?? 0;
+    const found = (testNapi.findToplevelAt(x, y) as number) ?? 0;
+    const tl = found > 0 ? found : this.fallbackToplevelId();
     this.cachedMoveTl = tl;
     this.cachedMoveTlX = x;
     this.cachedMoveTlY = y;
@@ -975,7 +995,8 @@ export struct VirtualInputOverlay {
   }
 
   private clickAtCursor(btn: number): void {
-    const tl = this.tlAtCursor();
+    let tl = this.tlAtCursor();
+    if (tl <= 0) tl = this.fallbackToplevelId();
     if (tl <= 0) return;
     testNapi.raiseToplevel(tl);
     const x = Math.round(this.vcX);
@@ -1100,9 +1121,7 @@ export struct VirtualInputOverlay {
           this.tpMoved = true;
         }
       }
-      this.vcX = this.vcX + dxPx;
-      this.vcY = this.vcY + dyPx;
-      this.clampCursor();
+      this.applyCursorDelta(dxPx, dyPx);
       if (this.tpDragArmed && !this.tpDragging && this.tpMoved) {
         // 拖拽开始: 在光标处按下左键 (拖动窗口/元素)
         this.tpDragging = true;
@@ -1113,7 +1132,8 @@ export struct VirtualInputOverlay {
             Math.round(this.vcX), Math.round(this.vcY), mapMouseButton(1));
         }
       }
-      const moveTl = this.tpDragging ? this.tpDragTl : this.tlAtCursor();
+      let moveTl = this.tpDragging ? this.tpDragTl : this.tlAtCursor();
+      if (moveTl <= 0) moveTl = this.fallbackToplevelId();
       if (moveTl > 0) {
         testNapi.sendPointerEvent(moveTl, MouseAction.Move,
           Math.round(this.vcX), Math.round(this.vcY), 0);
@@ -1154,33 +1174,34 @@ export struct VirtualInputOverlay {
       return;
     }
     // 触摸板模式: 虚拟光标全局状态机 (吞掉触摸, 不穿透到下层 Wine)。
-    // 触摸落在可点击按钮 (BUTTON/RANGE_BUTTON) 上时优先触发按钮,
-    // 其余区域 (含视角/摇杆/方向) 走全局触摸板手势。
+    // 按钮/摇杆/方向/视角框仍优先走各自控件；其余空白才是触控板。
     if (this.touchpadModeVisual) {
       event.stopPropagation();
       const touch = event.changedTouches[0];
       const x = Number(touch.x);
       const y = Number(touch.y);
-      const activeId = this.activeElementIdForTouch(touch.id);
       let claimed = false;
-      if (activeId.length > 0) {
-        const element = this.elementById(activeId);
-        if (element && (element.type === ControlElementType.BUTTON || element.type === ControlElementType.RANGE_BUTTON)) {
-          this.handleElementTouch(event, element);
-          claimed = true;
-        }
-      } else if (event.type === TouchType.Down) {
-        const target = this.elementAt(x, y);
-        if (target && (target.type === ControlElementType.BUTTON || target.type === ControlElementType.RANGE_BUTTON)) {
-          this.handleElementTouch(event, target);
-          claimed = true;
+      if (this.overlayControlsActive()) {
+        const activeId = this.activeElementIdForTouch(touch.id);
+        if (activeId.length > 0) {
+          const element = this.elementById(activeId);
+          if (element && this.isOverlayControl(element)) {
+            this.handleElementTouch(event, element);
+            claimed = true;
+          }
+        } else if (event.type === TouchType.Down) {
+          const target = this.elementAt(x, y);
+          if (target && this.isOverlayControl(target)) {
+            this.handleElementTouch(event, target);
+            claimed = true;
+          }
         }
       }
       if (claimed) return;
       this.handleTouchpad(event);
       return;
     }
-    if (!this.interactive || !this.controlsVisible) {
+    if (!this.interactive || !this.overlayControlsActive()) {
       this.onUnhandledTouch(event);
       return;
     }
@@ -1286,7 +1307,7 @@ export struct VirtualInputOverlay {
       event.stopPropagation();
       return;
     }
-    if (!this.interactive || !this.controlsVisible || Date.now() - this.lastActionTouchAt <= 320) {
+    if (!this.interactive || !this.overlayControlsActive() || Date.now() - this.lastActionTouchAt <= 320) {
       this.onUnhandledMouse(event);
       return;
     }
@@ -1375,16 +1396,64 @@ export struct VirtualInputOverlay {
     .id('virtual-element-' + element.id)
   }
 
+  private dpadArmPoints(element: ControlElement, direction: string): number[][] {
+    const width = this.elementWidth(element);
+    const height = this.elementHeight(element);
+    const cx = width / 2;
+    const cy = height / 2;
+    const arm = Math.min(width, height) * 0.30;
+    const pad = this.winlatorStrokeWidth();
+    const gap = Math.min(width, height) * 0.07;
+    const tip = arm * 0.42;
+    if (direction === 'up') {
+      const inner = cy - gap;
+      return [
+        [cx - arm / 2, pad],
+        [cx + arm / 2, pad],
+        [cx + arm / 2, inner - tip],
+        [cx, inner],
+        [cx - arm / 2, inner - tip]
+      ];
+    }
+    if (direction === 'down') {
+      const inner = cy + gap;
+      return [
+        [cx - arm / 2, height - pad],
+        [cx + arm / 2, height - pad],
+        [cx + arm / 2, inner + tip],
+        [cx, inner],
+        [cx - arm / 2, inner + tip]
+      ];
+    }
+    if (direction === 'left') {
+      const inner = cx - gap;
+      return [
+        [pad, cy - arm / 2],
+        [pad, cy + arm / 2],
+        [inner - tip, cy + arm / 2],
+        [inner, cy],
+        [inner - tip, cy - arm / 2]
+      ];
+    }
+    const inner = cx + gap;
+    return [
+      [width - pad, cy - arm / 2],
+      [width - pad, cy + arm / 2],
+      [inner + tip, cy + arm / 2],
+      [inner, cy],
+      [inner + tip, cy - arm / 2]
+    ];
+  }
+
   @Builder
   private DPadArm(element: ControlElement, direction: string) {
-    Path()
+    Polygon()
       .width(this.elementWidth(element))
       .height(this.elementHeight(element))
-      .commands(this.dpadArmPath(element, direction))
+      .points(this.dpadArmPoints(element, direction))
       .fill(this.winlatorFill(this.isDpadDirectionPressed(element.id, direction)))
       .stroke(this.winlatorStrokeColor(element))
       .strokeWidth(this.winlatorStrokeWidth())
-      .strokeLineJoin(LineJoinStyle.Round)
   }
 
   @Builder
@@ -1433,6 +1502,7 @@ export struct VirtualInputOverlay {
       Stack()
         .width('100%').height('100%')
         .borderRadius(this.elementHeight(element) * 0.15)
+        .backgroundColor(this.winlatorFill(this.isElementPressed(element.id)))
         .border({ width: this.winlatorStrokeWidth(), color: this.winlatorStrokeColor(element) })
       Stack()
         .width(Math.max(8, this.elementWidth(element) - this.winlatorStrokeWidth() * 5))
@@ -1440,9 +1510,18 @@ export struct VirtualInputOverlay {
         .borderRadius(Math.max(2, this.elementHeight(element) * 0.15 -
           this.winlatorStrokeWidth() * 1.5))
         .border({ width: this.winlatorStrokeWidth() * 2, color: this.winlatorStrokeColor(element) })
+      if (this.stickState(element.id).active) {
+        Circle()
+          .width(Math.min(this.elementWidth(element), this.elementHeight(element)) * 0.28)
+          .height(Math.min(this.elementWidth(element), this.elementHeight(element)) * 0.28)
+          .fill(WINLATOR_THUMB_FILL)
+          .stroke(this.winlatorStrokeColor(element))
+          .strokeWidth(this.winlatorStrokeWidth())
+          .translate({ x: this.stickState(element.id).dx, y: this.stickState(element.id).dy })
+      }
       if (element.text.length > 0) {
         Text(element.text).fontSize(12 * (element.scale ?? 1))
-          .fontColor(WINLATOR_LIGHT)
+          .fontColor(this.winlatorTextColor(this.isElementPressed(element.id)))
       }
     }
     .width(this.elementWidth(element)).height(this.elementHeight(element))
@@ -1581,10 +1660,35 @@ export struct VirtualInputOverlay {
     this.redrawCrosshair();
   }
 
+  private overlayControlsActive(): boolean {
+    return this.editMode || this.controlsVisibleVisual;
+  }
+
   private onControlsVisibleChanged(): void {
     this.controlsVisibleVisual = this.controlsVisible;
-    if (this.controlsVisible) return;
+    if (this.controlsVisibleVisual) {
+      return;
+    }
     this.releaseAllElementTouches();
+  }
+
+  private onFloatingFullscreenChanged(): void {
+    if (!this.desktopFloatingFullscreen) {
+      return;
+    }
+    this.resetCursorToCenter();
+  }
+
+  private resetCursorToCenter(): void {
+    this.ensureScreenPx();
+    this.cachedMoveTl = -1;
+    if (this.scrWPx <= 0 || this.scrHPx <= 0) {
+      return;
+    }
+    this.vcInit = true;
+    this.vcX = this.scrWPx / 2;
+    this.vcY = this.scrHPx / 2;
+    this.syncCursorIndicator();
   }
 
   private onCrosshairStateChanged(): void {
@@ -1602,7 +1706,7 @@ export struct VirtualInputOverlay {
     if (element) this.drawCrosshair(element);
   }
 
-  /** 画红色虚线十字线：段长 14、间隔 8，中心加实心点。 */
+  /** 画红色虚线十字线：段长 14、间隔 8，中心加实心点。Canvas 默认单位是 vp。 */
   private drawCrosshair(element: ControlElement): void {
     if (this.overlayW <= 0 || this.overlayH <= 0) return;
     const ctx = this.crosshairContext;
@@ -1612,7 +1716,6 @@ export struct VirtualInputOverlay {
     ctx.strokeStyle = 'rgba(255, 59, 48, 0.85)';
     const dash = 14;
     const gap = 8;
-    // 竖线
     ctx.beginPath();
     let y = 0;
     while (y < this.overlayH) {
@@ -1622,7 +1725,6 @@ export struct VirtualInputOverlay {
       y = end + gap;
     }
     ctx.stroke();
-    // 横线
     ctx.beginPath();
     let x = 0;
     while (x < this.overlayW) {
@@ -1632,7 +1734,6 @@ export struct VirtualInputOverlay {
       x = end + gap;
     }
     ctx.stroke();
-    // 中心点
     ctx.beginPath();
     ctx.arc(center.x, center.y, 5, 0, Math.PI * 2);
     ctx.fillStyle = 'rgba(255, 59, 48, 0.9)';
@@ -1649,6 +1750,14 @@ export struct VirtualInputOverlay {
   aboutToDisappear(): void {
     this.cancelToolbarAutoHide();
     this.releaseAllElementTouches();
+  }
+
+  /** 箭头光标随短边缩放：手机约 16–18vp，平板不超过 24vp。热点在箭头尖。 */
+  private cursorSizeVp(): number {
+    const shortSide = Math.min(
+      this.overlayW > 0 ? this.overlayW : 360,
+      this.overlayH > 0 ? this.overlayH : 640);
+    return Math.round(Math.max(16, Math.min(24, shortSide * 0.048)));
   }
 
   private toolbarWidth(): number {
@@ -2069,8 +2178,8 @@ export struct VirtualInputOverlay {
       Text(this.renderRevision.toString()).width(0).height(0).opacity(0).hitTestBehavior(HitTestMode.None)
       if (this.touchpadModeVisual && this.showCursor && this.cursorVpX >= 0 && this.cursorVpY >= 0) {
         Image($r('app.media.virtual_mouse_arrow'))
-          .width(28)
-          .height(28)
+          .width(this.cursorSizeVp())
+          .height(this.cursorSizeVp())
           .objectFit(ImageFit.Contain)
           .interpolation(ImageInterpolation.Medium)
           .position({ x: this.cursorVpX, y: this.cursorVpY })
@@ -2093,10 +2202,15 @@ export struct VirtualInputOverlay {
     .onMouse((event: MouseEvent): void => this.handleOverlayMouse(event))
     .onAxisEvent((event?: AxisEvent): void => this.onUnhandledAxis(event))
     .onAreaChange((_oldValue: Area, area: Area): void => {
-      this.overlayW = area.width as number;
-      this.overlayH = area.height as number;
+      const nextW = area.width as number;
+      const nextH = area.height as number;
+      const jumped = Math.abs(nextW - this.overlayW) > 8 || Math.abs(nextH - this.overlayH) > 8;
+      this.overlayW = nextW;
+      this.overlayH = nextH;
       this.applyConfiguredToolbarPosition();
-      if (this.touchpadModeVisual && this.vcInit) {
+      if (jumped && this.touchpadModeVisual) {
+        this.resetCursorToCenter();
+      } else if (this.touchpadModeVisual && this.vcInit) {
         this.clampCursor();
       }
     })

--- a/entry/src/main/ets/components/VirtualInputOverlay.ets
+++ b/entry/src/main/ets/components/VirtualInputOverlay.ets
@@ -10,6 +10,7 @@ import {
   resolveVirtualJoystickDirection
 } from '../model/AppModels';
 import { InputDispatcher } from '../service/InputDispatcher';
+import { InputOverlayWindowCoordinator } from '../service/InputOverlayWindowCoordinator';
 import { mapMouseButton } from '../common/MouseMap';
 import { display } from '@kit.ArkUI';
 import testNapi from 'libentry.so';
@@ -43,11 +44,13 @@ interface StickVisualState {
   active: boolean;
 }
 
-const STROKE_COLOR = '#FF2196F3';
-const FILL_IDLE = '#CC404040';
-const FILL_PRESSED = '#FF2979FF';
-const TEXT_IDLE = '#FFE7F2FF';
-const TEXT_PRESSED = '#FFFFFFFF';
+/** Winlator ControlElement 配色：白描边、按下白填充、按下文字转黑。 */
+const WINLATOR_LIGHT = '#FFFFFFFF';
+const WINLATOR_DARK = '#FF000000';
+const WINLATOR_HIGHLIGHT = '#FF0277BD';
+const WINLATOR_CLEAR = '#00000000';
+/** 摇杆拇指填充：Winlator ColorUtils.setAlphaComponent(light, 50)。 */
+const WINLATOR_THUMB_FILL = '#32FFFFFF';
 
 /** Toggle 按钮长按锁定阈值（毫秒）：短按=点按，长按=锁定保持。 */
 const LONG_PRESS_LOCK_MS = 400;
@@ -70,6 +73,8 @@ export struct VirtualInputOverlay {
   @Prop @Watch('onControlBarPositionChanged') controlBarPositionX: number = 1;
   @Prop @Watch('onControlBarPositionChanged') controlBarPositionY: number = 0;
   @Prop @Watch('onTouchpadModeChanged') touchpadMode: boolean = false;
+  /** 触摸板箭头指针；关闭后仍移动与点击，只是不画光标。 */
+  @Prop showCursor: boolean = true;
   /** 浮窗模式全屏态: 控制栏显示 home 按钮 (缩回 Index 悬浮窗)。 */
   @StorageProp('desktopFloatingFullscreen') desktopFloatingFullscreen: boolean = false;
   /** 编辑器模式：不注入按键，元素可拖动/缩放并支持选中框。 */
@@ -148,10 +153,8 @@ export struct VirtualInputOverlay {
   private vcInit: boolean = false;
   private scrWPx: number = 0;
   private scrHPx: number = 0;
-  @State private cursorVpX: number = -100;  // 指示点 vp 坐标 (屏外=隐藏)
+  @State private cursorVpX: number = -100;  // 箭头尖 vp 坐标 (屏外=隐藏)
   @State private cursorVpY: number = -100;
-  @State private tpFlash: boolean = false;  // 点击 flash 动画
-  private tpFlashTimer: number = -1;
   // 双指轻点=右键: 两指快速落下又抬起且中点几乎不动
   private tpTwoFingerStartAt: number = 0;
   private tpTwoFingerStartMidX: number = 0;
@@ -264,10 +267,61 @@ export struct VirtualInputOverlay {
   }
 
   private elementRadius(element: ControlElement): number {
-    if (element.shape === ControlElementShape.ROUND_RECT) return Math.min(this.elementWidth(element), this.elementHeight(element)) * 0.28;
-    if (element.shape === ControlElementShape.RECT) return 4;
-    if (element.shape === ControlElementShape.SQUARE) return 6;
+    // 对齐 Winlator ControlElement.draw：ROUND_RECT 为半高胶囊，SQUARE 为 0.75s。
+    if (element.shape === ControlElementShape.ROUND_RECT) {
+      return this.elementHeight(element) * 0.5;
+    }
+    if (element.shape === ControlElementShape.RECT) {
+      return 0;
+    }
+    if (element.shape === ControlElementShape.SQUARE) {
+      return Math.min(this.elementWidth(element), this.elementHeight(element)) * 0.15;
+    }
     return Math.min(this.elementWidth(element), this.elementHeight(element)) / 2;
+  }
+
+  /** snappingSize = viewWidth / 100，strokeWidth = snappingSize × 0.25。 */
+  private winlatorStrokeWidth(): number {
+    return Math.max(1.25, this.overlayW / 400);
+  }
+
+  private winlatorStrokeColor(element: ControlElement): string {
+    return (this.editMode && this.selectedElementId === element.id) ? WINLATOR_HIGHLIGHT : WINLATOR_LIGHT;
+  }
+
+  private winlatorFill(pressed: boolean): string {
+    return pressed ? WINLATOR_LIGHT : WINLATOR_CLEAR;
+  }
+
+  private winlatorTextColor(pressed: boolean): string {
+    return pressed ? WINLATOR_DARK : WINLATOR_LIGHT;
+  }
+
+  private dpadArmPath(element: ControlElement, direction: string): string {
+    const w = this.elementWidth(element);
+    const h = this.elementHeight(element);
+    const inset = this.winlatorStrokeWidth() * 0.5;
+    const cx = w / 2;
+    const cy = h / 2;
+    const s = Math.min(w, h) / 14;
+    const ox = s * 2;
+    const oy = s * 3;
+    const start = s;
+    const pt = (x: number, y: number): string => x.toFixed(1) + ' ' + y.toFixed(1);
+    if (direction === 'up') {
+      return 'M ' + pt(cx, cy - start) + ' L ' + pt(cx - ox, cy - oy) + ' L ' + pt(cx - ox, inset) +
+        ' L ' + pt(cx + ox, inset) + ' L ' + pt(cx + ox, cy - oy) + ' Z';
+    }
+    if (direction === 'down') {
+      return 'M ' + pt(cx, cy + start) + ' L ' + pt(cx - ox, cy + oy) + ' L ' + pt(cx - ox, h - inset) +
+        ' L ' + pt(cx + ox, h - inset) + ' L ' + pt(cx + ox, cy + oy) + ' Z';
+    }
+    if (direction === 'left') {
+      return 'M ' + pt(cx - start, cy) + ' L ' + pt(cx - oy, cy - ox) + ' L ' + pt(inset, cy - ox) +
+        ' L ' + pt(inset, cy + ox) + ' L ' + pt(cx - oy, cy + ox) + ' Z';
+    }
+    return 'M ' + pt(cx + start, cy) + ' L ' + pt(cx + oy, cy - ox) + ' L ' + pt(w - inset, cy - ox) +
+      ' L ' + pt(w - inset, cy + ox) + ' L ' + pt(cx + oy, cy + ox) + ' Z';
   }
 
   /** 键盘键帽文字按实际键面尺寸放大, 保证平板/手机上清晰可读。 */
@@ -456,7 +510,8 @@ export struct VirtualInputOverlay {
   }
 
   private stickKnobSize(element: ControlElement): number {
-    return 44 * (element.scale ?? 1);
+    // Winlator thumbRadius = 3.5s，外环半径 6s，直径比 7/12。
+    return Math.min(this.elementWidth(element), this.elementHeight(element)) * (7 / 12);
   }
 
   private bindingSource(element: ControlElement, slot: string, touchId: number): string {
@@ -867,30 +922,36 @@ export struct VirtualInputOverlay {
 
   // -- 触摸板模式: 虚拟光标状态机 (移植 upstream main-ui DesktopLayer.handleTouchpad) --
   private ensureScreenPx(): void {
-    if (this.scrWPx > 0) return;
-    try {
-      const d = display.getDefaultDisplaySync();
-      this.scrWPx = d.width;
-      this.scrHPx = d.height;
-    } catch (_) {
-      this.scrWPx = 1280;
-      this.scrHPx = 800;
+    const rect = InputOverlayWindowCoordinator.getInstance().getOverlayWindowRect();
+    if (rect.width > 0 && rect.height > 0) {
+      this.scrWPx = rect.width;
+      this.scrHPx = rect.height;
+    } else if (this.overlayW > 0 && this.overlayH > 0) {
+      this.scrWPx = vp2px(this.overlayW);
+      this.scrHPx = vp2px(this.overlayH);
+    } else {
+      try {
+        const d = display.getDefaultDisplaySync();
+        this.scrWPx = d.width;
+        this.scrHPx = d.height;
+      } catch (_) {
+        this.scrWPx = 1280;
+        this.scrHPx = 800;
+      }
     }
   }
 
   private syncCursorIndicator(): void {
-    this.cursorVpX = px2vp(this.vcX) - 7;
-    this.cursorVpY = px2vp(this.vcY) - 7;
+    // 箭头热点在图片左上尖端，position 即热点，不要减半径、不要 markAnchor。
+    this.cursorVpX = px2vp(this.vcX);
+    this.cursorVpY = px2vp(this.vcY);
   }
 
-  /** 点击 flash: 指示点短暂放大变绿 (对齐 InputOverlay 原反馈)。 */
-  private flashCursorIndicator(): void {
-    this.tpFlash = true;
-    if (this.tpFlashTimer >= 0) clearTimeout(this.tpFlashTimer);
-    this.tpFlashTimer = setTimeout((): void => {
-      this.tpFlashTimer = -1;
-      this.tpFlash = false;
-    }, 90) as number;
+  private clampCursor(): void {
+    this.ensureScreenPx();
+    this.vcX = Math.min(Math.max(this.vcX, 0), this.scrWPx);
+    this.vcY = Math.min(Math.max(this.vcY, 0), this.scrHPx);
+    this.syncCursorIndicator();
   }
 
   // 性能: 光标移动时缓存目标 toplevel, 避免每次 move 都 native 查询
@@ -936,11 +997,6 @@ export struct VirtualInputOverlay {
     this.tpTwoFinger = false;
     this.tpLastTapTime = 0;
     this.cachedMoveTl = -1;
-    if (this.tpFlashTimer >= 0) {
-      clearTimeout(this.tpFlashTimer);
-      this.tpFlashTimer = -1;
-    }
-    this.tpFlash = false;
   }
 
   private handleTouchpad(ev: TouchEvent): void {
@@ -1044,9 +1100,9 @@ export struct VirtualInputOverlay {
           this.tpMoved = true;
         }
       }
-      this.vcX = Math.min(Math.max(this.vcX + dxPx, 0), this.scrWPx);
-      this.vcY = Math.min(Math.max(this.vcY + dyPx, 0), this.scrHPx);
-      this.syncCursorIndicator();
+      this.vcX = this.vcX + dxPx;
+      this.vcY = this.vcY + dyPx;
+      this.clampCursor();
       if (this.tpDragArmed && !this.tpDragging && this.tpMoved) {
         // 拖拽开始: 在光标处按下左键 (拖动窗口/元素)
         this.tpDragging = true;
@@ -1080,7 +1136,6 @@ export struct VirtualInputOverlay {
       if (!this.tpMoved) {
         // 轻点 = 左键 (右键走双指轻点, 保持虚拟鼠标本地语义)
         this.clickAtCursor(mapMouseButton(1));
-        this.flashCursorIndicator();
         this.tpLastTapTime = Date.now();
         this.tpLastTapVcX = this.vcX;
         this.tpLastTapVcY = this.vcY;
@@ -1293,8 +1348,8 @@ export struct VirtualInputOverlay {
     Stack()
       .width(this.elementWidth(element)).height(this.elementHeight(element))
       .borderRadius(this.elementRadius(element))
-      .backgroundColor('#B81A1D28')
-      .border({ width: 2, color: '#66FFFFFF' })
+      .backgroundColor(WINLATOR_CLEAR)
+      .border({ width: this.winlatorStrokeWidth(), color: this.winlatorStrokeColor(element) })
       .opacity(this.elementOpacity(element))
       .hitTestBehavior(HitTestMode.None)
       .position({ x: this.elementCenter(element).x - this.elementWidth(element) / 2,
@@ -1306,13 +1361,14 @@ export struct VirtualInputOverlay {
   private ButtonElement(element: ControlElement) {
     Stack({ alignContent: Alignment.Center }) {
       Text(element.text.length > 0 ? element.text : '键')
-        .fontSize(this.buttonLabelFontSize(element)).fontWeight(FontWeight.Bold).maxLines(1)
-        .fontColor(this.isElementPressed(element.id) ? TEXT_PRESSED : TEXT_IDLE)
+        .fontSize(this.buttonLabelFontSize(element)).fontWeight(FontWeight.Medium).maxLines(1)
+        .fontColor(this.winlatorTextColor(this.isElementPressed(element.id)))
     }
     .width(this.elementWidth(element)).height(this.elementHeight(element))
     .borderRadius(this.elementRadius(element))
-    .backgroundColor(this.isElementPressed(element.id) ? FILL_PRESSED : FILL_IDLE)
-    .border({ width: 2, color: this.isElementPressed(element.id) ? STROKE_COLOR : '#55FFFFFF' })
+    .backgroundColor(this.winlatorFill(this.isElementPressed(element.id)))
+    .border({ width: this.winlatorStrokeWidth(), color: this.winlatorStrokeColor(element) })
+    .clip(true)
     .opacity(this.elementOpacity(element))
     .hitTestBehavior(HitTestMode.None)
     .position({ x: this.elementCenter(element).x - this.elementWidth(element) / 2, y: this.elementCenter(element).y - this.elementHeight(element) / 2 })
@@ -1320,43 +1376,26 @@ export struct VirtualInputOverlay {
   }
 
   @Builder
+  private DPadArm(element: ControlElement, direction: string) {
+    Path()
+      .width(this.elementWidth(element))
+      .height(this.elementHeight(element))
+      .commands(this.dpadArmPath(element, direction))
+      .fill(this.winlatorFill(this.isDpadDirectionPressed(element.id, direction)))
+      .stroke(this.winlatorStrokeColor(element))
+      .strokeWidth(this.winlatorStrokeWidth())
+      .strokeLineJoin(LineJoinStyle.Round)
+  }
+
+  @Builder
   private DPadElement(element: ControlElement) {
     Stack() {
-      // 圆形底座
-      Circle()
-        .width(this.elementWidth(element)).height(this.elementHeight(element))
-        .fill('#33404040')
-        .stroke(this.isElementPressed(element.id) ? '#FF4CAF50' : STROKE_COLOR)
-        .strokeWidth(2)
-      // 小霸王风格十字键：细臂直角，无圆角无箭头文字，置于圆内。
-      // 上臂
-      Stack()
-        .width(this.elementWidth(element) * 0.30).height(this.elementWidth(element) * 0.42)
-        .backgroundColor(this.isDpadDirectionPressed(element.id, 'up') ? FILL_PRESSED : FILL_IDLE)
-        .position({ x: this.elementWidth(element) * 0.35, y: this.elementWidth(element) * 0.04 })
-      // 下臂
-      Stack()
-        .width(this.elementWidth(element) * 0.30).height(this.elementWidth(element) * 0.42)
-        .backgroundColor(this.isDpadDirectionPressed(element.id, 'down') ? FILL_PRESSED : FILL_IDLE)
-        .position({ x: this.elementWidth(element) * 0.35, y: this.elementWidth(element) * 0.54 })
-      // 左臂
-      Stack()
-        .width(this.elementWidth(element) * 0.42).height(this.elementWidth(element) * 0.30)
-        .backgroundColor(this.isDpadDirectionPressed(element.id, 'left') ? FILL_PRESSED : FILL_IDLE)
-        .position({ x: this.elementWidth(element) * 0.04, y: this.elementWidth(element) * 0.35 })
-      // 右臂
-      Stack()
-        .width(this.elementWidth(element) * 0.42).height(this.elementWidth(element) * 0.30)
-        .backgroundColor(this.isDpadDirectionPressed(element.id, 'right') ? FILL_PRESSED : FILL_IDLE)
-        .position({ x: this.elementWidth(element) * 0.54, y: this.elementWidth(element) * 0.35 })
-      // 中心方块
-      Stack()
-        .width(this.elementWidth(element) * 0.30).height(this.elementWidth(element) * 0.30)
-        .backgroundColor(this.isElementPressed(element.id) ? FILL_PRESSED : FILL_IDLE)
-        .position({ x: this.elementWidth(element) * 0.35, y: this.elementWidth(element) * 0.35 })
+      this.DPadArm(element, 'up')
+      this.DPadArm(element, 'right')
+      this.DPadArm(element, 'down')
+      this.DPadArm(element, 'left')
     }
     .width(this.elementWidth(element)).height(this.elementHeight(element))
-    .borderRadius(this.elementRadius(element))
     .opacity(this.elementOpacity(element))
     .hitTestBehavior(HitTestMode.None)
     .position({ x: this.elementCenter(element).x - this.elementWidth(element) / 2, y: this.elementCenter(element).y - this.elementHeight(element) / 2 })
@@ -1367,16 +1406,17 @@ export struct VirtualInputOverlay {
   private StickElement(element: ControlElement) {
     Stack({ alignContent: Alignment.Center }) {
       Circle().width(this.elementWidth(element)).height(this.elementHeight(element))
-        .fill('#33404040').stroke(STROKE_COLOR).strokeWidth(2)
+        .fill(WINLATOR_CLEAR).stroke(this.winlatorStrokeColor(element)).strokeWidth(this.winlatorStrokeWidth())
       Stack({ alignContent: Alignment.Center }) {
         Circle().width(this.stickKnobSize(element)).height(this.stickKnobSize(element))
-          .fill(this.stickState(element.id).active ? FILL_PRESSED : '#CC606060')
-          .stroke('#AAFFFFFF').strokeWidth(2)
+          .fill(WINLATOR_THUMB_FILL)
+          .stroke(this.winlatorStrokeColor(element))
+          .strokeWidth(this.winlatorStrokeWidth())
       }
       .translate({ x: this.stickState(element.id).dx, y: this.stickState(element.id).dy })
       if (element.text.length > 0) {
-        Text(element.text).fontSize(12 * (element.scale ?? 1)).fontWeight(FontWeight.Bold)
-          .fontColor(this.stickState(element.id).active ? TEXT_PRESSED : TEXT_IDLE)
+        Text(element.text).fontSize(12 * (element.scale ?? 1)).fontWeight(FontWeight.Medium)
+          .fontColor(WINLATOR_LIGHT)
           .translate({ x: 0, y: this.elementHeight(element) / 2 + 8 * (element.scale ?? 1) })
       }
     }
@@ -1390,13 +1430,23 @@ export struct VirtualInputOverlay {
   @Builder
   private TrackpadElement(element: ControlElement) {
     Stack({ alignContent: Alignment.Center }) {
-      Text(element.text.length > 0 ? element.text : '视角').fontSize(12 * (element.scale ?? 1))
-        .fontColor(this.isElementPressed(element.id) ? '#FFB9F6CA' : '#88FFFFFF')
+      Stack()
+        .width('100%').height('100%')
+        .borderRadius(this.elementHeight(element) * 0.15)
+        .border({ width: this.winlatorStrokeWidth(), color: this.winlatorStrokeColor(element) })
+      Stack()
+        .width(Math.max(8, this.elementWidth(element) - this.winlatorStrokeWidth() * 5))
+        .height(Math.max(8, this.elementHeight(element) - this.winlatorStrokeWidth() * 5))
+        .borderRadius(Math.max(2, this.elementHeight(element) * 0.15 -
+          this.winlatorStrokeWidth() * 1.5))
+        .border({ width: this.winlatorStrokeWidth() * 2, color: this.winlatorStrokeColor(element) })
+      if (element.text.length > 0) {
+        Text(element.text).fontSize(12 * (element.scale ?? 1))
+          .fontColor(WINLATOR_LIGHT)
+      }
     }
     .width(this.elementWidth(element)).height(this.elementHeight(element))
-    .borderRadius(this.elementRadius(element))
-    .backgroundColor(this.isElementPressed(element.id) ? '#B04CAF50' : '#33404040')
-    .border({ width: 2, color: this.isElementPressed(element.id) ? '#FF4CAF50' : STROKE_COLOR })
+    .backgroundColor(WINLATOR_CLEAR)
     .opacity(this.elementOpacity(element))
     .hitTestBehavior(HitTestMode.None)
     .position({ x: this.elementCenter(element).x - this.elementWidth(element) / 2, y: this.elementCenter(element).y - this.elementHeight(element) / 2 })
@@ -1407,26 +1457,34 @@ export struct VirtualInputOverlay {
   private RangeButtonElement(element: ControlElement) {
     Stack({ alignContent: Alignment.Top }) {
       if (element.text.length > 0 && element.orientation !== 'horizontal') {
-        Text(element.text).fontSize(10 * (element.scale ?? 1)).fontColor(TEXT_IDLE)
+        Text(element.text).fontSize(10 * (element.scale ?? 1)).fontColor(WINLATOR_LIGHT)
           .padding(3).width('100%').textAlign(TextAlign.Center)
       }
       ForEach(element.keyList ?? [], (code: number, index: number): void => {
         Stack({ alignContent: Alignment.Center }) {
+          if (index > 0 && this.rangeSelection(element.id) !== index &&
+            this.rangeSelection(element.id) !== index - 1) {
+            Row()
+              .width(element.orientation === 'horizontal' ? this.winlatorStrokeWidth() : '100%')
+              .height(element.orientation === 'horizontal' ? '100%' : this.winlatorStrokeWidth())
+              .backgroundColor(this.winlatorStrokeColor(element))
+              .position(element.orientation === 'horizontal' ? { x: 0, y: 0 } : { x: 0, y: 0 })
+          }
           Text(this.keyLabel(code)).fontSize((element.orientation === 'horizontal' ? 8 : 10) * (element.scale ?? 1))
-            .fontColor(this.rangeSelection(element.id) === index ? TEXT_PRESSED : TEXT_IDLE)
+            .fontColor(this.winlatorTextColor(this.rangeSelection(element.id) === index))
         }
         .width(element.orientation === 'horizontal' ? this.rangeSlotHeight(element) : '100%')
         .height(element.orientation === 'horizontal' ? '100%' : this.rangeSlotHeight(element))
-        .backgroundColor(this.rangeSelection(element.id) === index ? FILL_PRESSED : '#44000000')
+        .backgroundColor(this.winlatorFill(this.rangeSelection(element.id) === index))
         .position(element.orientation === 'horizontal' ?
           { x: this.rangeSlotTop(element) + index * this.rangeSlotHeight(element), y: 0 } :
           { x: 0, y: this.rangeSlotTop(element) + index * this.rangeSlotHeight(element) })
       }, (code: number, index: number): string => element.id + '-' + code.toString() + '-' + index.toString())
     }
     .width(this.elementWidth(element)).height(this.elementHeight(element))
-    .borderRadius(this.elementRadius(element))
-    .backgroundColor('#33404040')
-    .border({ width: 2, color: STROKE_COLOR })
+    .borderRadius(Math.min(this.elementWidth(element), this.elementHeight(element)) * 0.15)
+    .backgroundColor(WINLATOR_CLEAR)
+    .border({ width: this.winlatorStrokeWidth(), color: this.winlatorStrokeColor(element) })
     .clip(true)
     .opacity(this.elementOpacity(element))
     .hitTestBehavior(HitTestMode.None)
@@ -1504,6 +1562,15 @@ export struct VirtualInputOverlay {
 
   private onTouchpadModeChanged(): void {
     this.touchpadModeVisual = this.touchpadMode;
+    if (this.touchpadMode) {
+      this.ensureScreenPx();
+      if (!this.vcInit && this.scrWPx > 0 && this.scrHPx > 0) {
+        this.vcInit = true;
+        this.vcX = this.scrWPx / 2;
+        this.vcY = this.scrHPx / 2;
+      }
+      this.clampCursor();
+    }
   }
 
   private onProfileChanged(): void {
@@ -2000,13 +2067,12 @@ export struct VirtualInputOverlay {
   build() {
     Stack() {
       Text(this.renderRevision.toString()).width(0).height(0).opacity(0).hitTestBehavior(HitTestMode.None)
-      // 触摸板模式虚拟光标指示点 (原样式: 小圆 7px, 点击 flash 10px 绿)
-      if (this.touchpadModeVisual && this.cursorVpX >= 0 && this.cursorVpY >= 0) {
-        Circle({ width: this.tpFlash ? 10 : 7, height: this.tpFlash ? 10 : 7 })
-          .fill(this.tpFlash ? '#FF4CAF50' : '#E6FFFFFF')
-          .stroke(this.tpFlash ? '#CCB9F6CA' : '#D9000000')
-          .strokeWidth(1)
-          .shadow({ radius: this.tpFlash ? 8 : 4, color: '#66000000', offsetX: 0, offsetY: 1 })
+      if (this.touchpadModeVisual && this.showCursor && this.cursorVpX >= 0 && this.cursorVpY >= 0) {
+        Image($r('app.media.virtual_mouse_arrow'))
+          .width(28)
+          .height(28)
+          .objectFit(ImageFit.Contain)
+          .interpolation(ImageInterpolation.Medium)
           .position({ x: this.cursorVpX, y: this.cursorVpY })
           .hitTestBehavior(HitTestMode.None)
           .zIndex(50)
@@ -2030,6 +2096,9 @@ export struct VirtualInputOverlay {
       this.overlayW = area.width as number;
       this.overlayH = area.height as number;
       this.applyConfiguredToolbarPosition();
+      if (this.touchpadModeVisual && this.vcInit) {
+        this.clampCursor();
+      }
     })
   }
 }

--- a/entry/src/main/ets/entryability/DesktopAbility.ets
+++ b/entry/src/main/ets/entryability/DesktopAbility.ets
@@ -105,7 +105,7 @@ export default class DesktopAbility extends UIAbility {
           // a landscape launch. Apply the window chrome first, then wait for
           // the final rectangle before the first compositor resize.
           await this.applyDesktopWindowMode(mw);
-          await this.waitForRequestedOrientation(mw);
+          await DeviceCapabilityPolicy.waitForRequestedOrientation(mw, this.desktopOrientation, TAG);
           this.applyKeepScreenOn(mw);
 
           // 输出尺寸以 XComponent surface 为唯一权威 (onSurfaceChanged → 
@@ -159,6 +159,7 @@ export default class DesktopAbility extends UIAbility {
         this.attachVirtualDesktopStatus(target);
         this.immersiveMaximized = true;
         WineWindowManager.getInstance().enterImmersiveFullscreen(target, 0);
+        AppStorage.setOrCreate('vdImmersive', true);
         hilog.info(DOMAIN, TAG, '[DWA] pc-virtual auto immersive (DISABLE_HOVER)');
       } catch (e) {
         hilog.warn(DOMAIN, TAG, '[DWA] pc-virtual immersive setup partial: %{public}s',
@@ -201,29 +202,6 @@ export default class DesktopAbility extends UIAbility {
       } catch (_) {
       }
       hilog.info(DOMAIN, TAG, '[DWA] desktop window fullscreen layout applied');
-    }
-  }
-
-  private async waitForRequestedOrientation(target: window.Window): Promise<void> {
-    const needLandscape = this.desktopOrientation !== ScreenOrientationSetting.PORTRAIT;
-    for (let attempt = 0; attempt < 16; attempt++) {
-      try {
-        const rect = target.getWindowProperties().windowRect;
-        if (rect.width > 0 && rect.height > 0 &&
-          (needLandscape ? rect.width >= rect.height : rect.height >= rect.width)) {
-          hilog.info(DOMAIN, TAG, '[DWA] final window rect=%{public}dx%{public}d orientation=%{public}s',
-            rect.width, rect.height, this.desktopOrientation);
-          return;
-        }
-      } catch (_) {
-      }
-      await new Promise<void>((resolve: () => void) => setTimeout(resolve, 100));
-    }
-    try {
-      const rect = target.getWindowProperties().windowRect;
-      hilog.warn(DOMAIN, TAG, '[DWA] orientation settle timeout rect=%{public}dx%{public}d requested=%{public}s',
-        rect.width, rect.height, this.desktopOrientation);
-    } catch (_) {
     }
   }
 
@@ -317,12 +295,12 @@ export default class DesktopAbility extends UIAbility {
     target.on('windowStatusChange', (statusType: number) => {
       hilog.info(DOMAIN, TAG, '[DWA] windowStatusChange status=%{public}d immersive=%{public}s',
         statusType, this.immersiveMaximized ? 'yes' : 'no');
-      if (statusType === window.WindowStatusType.MAXIMIZE) {
+      if (statusType === window.WindowStatusType.MAXIMIZE ||
+        statusType === window.WindowStatusType.FULL_SCREEN) {
         if (!this.immersiveMaximized) {
           this.immersiveMaximized = true;
           WineWindowManager.getInstance().enterImmersiveFullscreen(target, 0);
         }
-      } else if (statusType === window.WindowStatusType.FULL_SCREEN) {
         AppStorage.setOrCreate('vdImmersive', true);
       } else {
         if (this.immersiveMaximized) {

--- a/entry/src/main/ets/entryability/DesktopAbility.ets
+++ b/entry/src/main/ets/entryability/DesktopAbility.ets
@@ -1,6 +1,6 @@
 import { AbilityConstant, UIAbility, Want } from '@kit.AbilityKit';
 import { hilog } from '../service/LogService';
-import { window, display } from '@kit.ArkUI';
+import { window } from '@kit.ArkUI';
 import testNapi from 'libentry.so';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { WineWindowManager } from '../service/WineWindowManager';
@@ -25,6 +25,8 @@ export default class DesktopAbility extends UIAbility {
   private windowResizeGeneration: number = 0;
   private desktopOrientation: ScreenOrientationSetting = ScreenOrientationSetting.SENSOR_LANDSCAPE;
   private lastAppliedWindowMode: string = '';
+  private immersiveMaximized: boolean = false;
+  private vdStatusAttached: boolean = false;
 
   onCreate(want: Want, launchParam: AbilityConstant.LaunchParam): void {
     try {
@@ -83,6 +85,10 @@ export default class DesktopAbility extends UIAbility {
       }
       hilog.info(DOMAIN, TAG, '[DWA] loadContent OK tl=%{public}d', this.toplevelId);
 
+      this.immersiveMaximized = false;
+      this.vdStatusAttached = false;
+      AppStorage.setOrCreate('vdImmersive', false);
+
       // 沉浸模式: 全屏 + 隐藏状态栏和导航栏
       void this.finishDesktopWindowSetup(windowStage);
     });
@@ -138,44 +144,28 @@ export default class DesktopAbility extends UIAbility {
       WineWindowManager.getInstance().isDesktopMode) {
       try {
         await target.setWindowLayoutFullScreen(false);
-        // 隐藏系统标题栏: 桌面窗口无标题栏, 最大化/关闭经顶部 hover 控制条
-        // (DesktopWindow.ets 反色控制条)。隐藏后 XComponent 从窗口顶部铺满,
-        // 与 master VirtualDesktop 无偏移语义一致。
         try {
-          target.setWindowDecorVisible(false);
-        } catch (err) {
-          hilog.warn(DOMAIN, TAG, '[DWA] pc-virtual hide decor skipped: %{public}s', JSON.stringify(err));
+          target.setWindowTitle('Wine 桌面');
+        } catch (_) {
         }
-        // 对齐上游 VirtualDesktopAbility: PC 虚拟桌面浮窗不强制显示系统
-        // 状态栏/导航条 — 强制 status=true 会让浮窗顶部多出系统状态栏,
-        // 内容区/输入坐标基准向下偏移一个状态栏高度 (≈一个文字高度),
-        // 鼠标光标相对游戏光标整体偏下。隐藏系统栏后 XComponent 从窗口
-        // 顶部铺满内容区。
+        // 保留系统标题栏: 沉浸全屏由 maximize(DISABLE_HOVER) 隐藏, 还原后
+        // 标题栏回来供关闭/最小化。不要 setWindowDecorVisible(false),
+        // 也不要用 resize(屏幕) 冒充全屏 (会和 immersive 抢几何、弄歪鼠标)。
         await Promise.all([
           target.setSpecificSystemBarEnabled('status', false),
           target.setSpecificSystemBarEnabled('navigationIndicator', false)
         ]);
         await target.setWindowBackgroundColor('#000000');
-        // 启动自动全屏: resize 到屏幕 100% + 移动到 (0,0), 铺满整个显示区。
-        // 标题栏/系统栏已隐藏 → 即沉浸全屏效果。顶部 hover 控制条提供
-        // 还原(90% 浮窗)/最小化/关闭, 还原后进入可缩放的窗口模式。
-        try {
-          const d = display.getDefaultDisplaySync();
-          await target.resize(d.width, d.height);
-          await target.moveWindowTo(0, 0);
-          AppStorage.setOrCreate('vdImmersive', true);
-          hilog.info(DOMAIN, TAG, '[DWA] pc-virtual auto fullscreen %{public}dx%{public}d',
-            d.width, d.height);
-        } catch (err) {
-          hilog.warn(DOMAIN, TAG, '[DWA] pc-virtual fullscreen skipped: %{public}s',
-            JSON.stringify(err));
-        }
+        this.attachVirtualDesktopStatus(target);
+        this.immersiveMaximized = true;
+        WineWindowManager.getInstance().enterImmersiveFullscreen(target, 0);
+        hilog.info(DOMAIN, TAG, '[DWA] pc-virtual auto immersive (DISABLE_HOVER)');
       } catch (e) {
-        hilog.warn(DOMAIN, TAG, '[DWA] pc-virtual floating setup partial: %{public}s',
+        hilog.warn(DOMAIN, TAG, '[DWA] pc-virtual immersive setup partial: %{public}s',
           JSON.stringify(e));
       }
       this.lastAppliedWindowMode = 'pc-virtual';
-      hilog.info(DOMAIN, TAG, '[DWA] pc virtual desktop: floating window sized to screen');
+      hilog.info(DOMAIN, TAG, '[DWA] pc virtual desktop: immersive fullscreen');
       return;
     }
     const mode = AppSettingsStore.getInstance().getGlobalSettings().desktopWindowMode
@@ -315,6 +305,32 @@ export default class DesktopAbility extends UIAbility {
     } catch (e) {
       hilog.error(DOMAIN, TAG, '[DWA] ERR onDestroy: %{public}s', JSON.stringify(e));
     }
+  }
+
+  /**
+   * PC 虚拟桌面: 最大化 → 沉浸全屏 (DISABLE_HOVER), 还原后标题栏回归。
+   * WindowStatusType: 1=FULL_SCREEN 2=MAXIMIZE 4=FLOATING。
+   */
+  private attachVirtualDesktopStatus(target: window.Window): void {
+    if (this.vdStatusAttached) return;
+    this.vdStatusAttached = true;
+    target.on('windowStatusChange', (statusType: number) => {
+      hilog.info(DOMAIN, TAG, '[DWA] windowStatusChange status=%{public}d immersive=%{public}s',
+        statusType, this.immersiveMaximized ? 'yes' : 'no');
+      if (statusType === window.WindowStatusType.MAXIMIZE) {
+        if (!this.immersiveMaximized) {
+          this.immersiveMaximized = true;
+          WineWindowManager.getInstance().enterImmersiveFullscreen(target, 0);
+        }
+      } else if (statusType === window.WindowStatusType.FULL_SCREEN) {
+        AppStorage.setOrCreate('vdImmersive', true);
+      } else {
+        if (this.immersiveMaximized) {
+          this.immersiveMaximized = false;
+        }
+        AppStorage.setOrCreate('vdImmersive', false);
+      }
+    });
   }
 
   /** 桌面打开期间按设置保持屏幕常亮，避免游玩中自动锁屏。 */

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -3,6 +3,7 @@ import { hilog } from '../service/LogService';
 import { AppLog } from '../service/LogService';
 import { display, window } from '@kit.ArkUI';
 import { WineWindowManager } from '../service/WineWindowManager';
+import { InputOverlayWindowCoordinator } from '../service/InputOverlayWindowCoordinator';
 import { AppCatalogService, GamesDirectoryStatus } from '../service/AppCatalogService';
 import { DeviceCapabilityPolicy } from '../common/DeviceCapabilityPolicy';
 import testNapi from 'libentry.so';
@@ -11,6 +12,7 @@ const DOMAIN = 0x0000;
 export default class EntryAbility extends UIAbility {
   private mainWindow: window.Window | null = null;
   private titleButtonRectCallback: ((rect: window.TitleButtonRect) => void) | null = null;
+  private windowRectCallback: (() => void) | null = null;
   // A routed page can briefly change the window layout while it enters or
   // leaves an editor. That transaction reports an empty title-button rect on
   // some tablet/desktop shells even though the controls return afterwards.
@@ -106,6 +108,15 @@ export default class EntryAbility extends UIAbility {
         // below every routed page. Gesture navigation remains available.
         mainWin.setSpecificSystemBarEnabled('navigationIndicator', false).catch(() => {});
         this.observeTitleButtonInset(mainWin);
+        this.windowRectCallback = (): void => {
+          InputOverlayWindowCoordinator.getInstance().syncBounds().catch(() => {});
+        };
+        try {
+          mainWin.on('windowRectChange', this.windowRectCallback);
+        } catch (error) {
+          hilog.warn(DOMAIN, 'EntryAbility', 'windowRectChange unavailable: %{public}s',
+            JSON.stringify(error));
+        }
       }
       hilog.info(DOMAIN, 'testTag', 'Succeeded in loading the content.');
     });
@@ -124,7 +135,14 @@ export default class EntryAbility extends UIAbility {
       } catch (_) {
       }
     }
+    if (this.mainWindow && this.windowRectCallback) {
+      try {
+        this.mainWindow.off('windowRectChange', this.windowRectCallback);
+      } catch (_) {
+      }
+    }
     this.titleButtonRectCallback = null;
+    this.windowRectCallback = null;
     this.mainWindow = null;
     AppStorage.setOrCreate('libraryTitleButtonInsetVp', 0);
   }

--- a/entry/src/main/ets/model/AppModels.ets
+++ b/entry/src/main/ets/model/AppModels.ets
@@ -668,7 +668,7 @@ export interface InputTemplate {
 export const INPUT_TEMPLATES: InputTemplate[] = [
   {
     id: 'default', name: '通用', description: '方向键、鼠标和常用功能键',
-    builtInProfileId: 'default', profileName: '默认输入方案', revision: 3
+    builtInProfileId: 'default', profileName: '默认输入方案', revision: 4
   },
   {
     id: 'full-keyboard', name: '全键盘', description: '完整字母、数字、功能键与方向键',
@@ -708,12 +708,12 @@ function arrowBindings(): InputBinding[] {
 
 function defaultTemplateElements(): ControlElement[] {
   return [
-    createControlElement(ControlElementType.D_PAD, 0.12, 0.78, '', dpadWASD()),
+    createControlElement(ControlElementType.D_PAD, 0.12, 0.70, '', dpadWASD()),
     createControlElement(ControlElementType.TRACKPAD, 0.68, 0.76, '视角', []),
-    createControlElement(ControlElementType.BUTTON, 0.86, 0.70, '空格', [keyBinding(57)]),
-    createControlElement(ControlElementType.BUTTON, 0.94, 0.70, '左键', [mouseBinding(MOUSE_LEFT_BUTTON)]),
-    createControlElement(ControlElementType.BUTTON, 0.86, 0.82, 'E', [keyBinding(18)]),
-    createControlElement(ControlElementType.BUTTON, 0.94, 0.82, '右键', [mouseBinding(MOUSE_RIGHT_BUTTON)]),
+    createControlElement(ControlElementType.BUTTON, 0.86, 0.62, '空格', [keyBinding(57)]),
+    createControlElement(ControlElementType.BUTTON, 0.94, 0.62, '左键', [mouseBinding(MOUSE_LEFT_BUTTON)]),
+    createControlElement(ControlElementType.BUTTON, 0.86, 0.84, 'E', [keyBinding(18)]),
+    createControlElement(ControlElementType.BUTTON, 0.94, 0.84, '右键', [mouseBinding(MOUSE_RIGHT_BUTTON)]),
     createControlElement(ControlElementType.BUTTON, 0.06, 0.16, 'Esc', [keyBinding(1)], ControlElementShape.ROUND_RECT, 0.72),
     createControlElement(ControlElementType.BUTTON, 0.14, 0.16, 'Shift', [keyBinding(42)], ControlElementShape.ROUND_RECT, 0.72, true),
     createControlElement(ControlElementType.BUTTON, 0.22, 0.16, 'Ctrl', [keyBinding(29)], ControlElementShape.ROUND_RECT, 0.72, true)

--- a/entry/src/main/ets/model/AppModels.ets
+++ b/entry/src/main/ets/model/AppModels.ets
@@ -43,7 +43,8 @@ export enum SessionState {
 export enum ViewMode {
   GRID = 'grid',
   COMPACT = 'compact',
-  LARGE = 'large'
+  LARGE = 'large',
+  FILES = 'files'
 }
 
 export enum ThemeMode {
@@ -335,6 +336,8 @@ export interface GlobalSettings {
   gamepadDeadzone: number;
   outputScale: number;
   d3dRendererPreference: D3DRendererPreference;
+  /** 重置 Wine prefix 时默认保留文档目录与注册表，只重建沙盒。 */
+  preserveUserDataOnReset: boolean;
 }
 
 export interface RuntimeSession {
@@ -943,7 +946,8 @@ export function createDefaultGlobalSettings(): GlobalSettings {
     controlOpacity: 72,
     gamepadDeadzone: 18,
     outputScale: 100,
-    d3dRendererPreference: D3DRendererPreference.DXVK
+    d3dRendererPreference: D3DRendererPreference.DXVK,
+    preserveUserDataOnReset: true
   };
 }
 

--- a/entry/src/main/ets/pages/DesktopWindow.ets
+++ b/entry/src/main/ets/pages/DesktopWindow.ets
@@ -1,49 +1,114 @@
+import { display } from '@kit.ArkUI';
+import { preferences } from '@kit.ArkData';
 import { DesktopLayer } from '../components/DesktopLayer';
 import { WineWindowManager } from '../service/WineWindowManager';
 
-// 桌面全屏窗口 (DesktopAbility 承载): 桌面全部逻辑 (renderer 生命周期 /
-// 触控状态机 / 触控板 / 鼠标 / 键盘 / 滚轮 / 虚拟输入 overlay) 复用
-// components/DesktopLayer (含 floating 态)。全屏态 floating=false 输入全直通。
-// PC 虚拟桌面: 标题栏已隐藏, 顶部 hover 显示反色控制条 (最小化/退出全屏/关闭)。
+const EXIT_BTN_PREF_FILE = 'vd_exit_btn';
+const EXIT_BTN_PREF_X = 'x';
+const EXIT_BTN_PREF_Y = 'y';
+const EXIT_BTN_SIZE = 48;
+const EXIT_DRAG_THRESHOLD = 5;
+
+// 桌面全屏窗口 (DesktopAbility 承载)。PC 虚拟桌面沉浸态不画系统关闭条,
+// 只留可拖动的小圆形还原钮 (对齐 main-ui VirtualDesktop)。
 @Entry
 @Component
 struct DesktopPage {
-  // 顶部 hover 菜单态: 鼠标移入窗口顶部热区 → 显示控制条, 移出自动隐藏
-  @State hoverMenu: boolean = false;
+  @StorageProp('vdImmersive') immersive: boolean = false;
+  @State btnX: number = 0;
+  @State btnY: number = 0;
+  private scrW: number = 0;
+  private scrH: number = 0;
+  private startX: number = 0;
+  private startY: number = 0;
+  private startBtnX: number = 0;
+  private startBtnY: number = 0;
+  private dragMoved: boolean = false;
+
+  aboutToAppear(): void {
+    const d = display.getDefaultDisplaySync();
+    this.scrW = px2vp(d.width);
+    this.scrH = px2vp(d.height);
+    this.btnX = this.scrW * 0.84 - EXIT_BTN_SIZE;
+    this.btnY = 20;
+    this.loadBtnPos();
+  }
+
+  private loadBtnPos(): void {
+    preferences.getPreferences(getContext(this), EXIT_BTN_PREF_FILE).then((prefs: preferences.Preferences) => {
+      const x = prefs.getSync(EXIT_BTN_PREF_X, -1) as number;
+      const y = prefs.getSync(EXIT_BTN_PREF_Y, -1) as number;
+      if (x >= 0 && y >= 0) {
+        this.btnX = Math.min(Math.max(0, x), this.scrW - EXIT_BTN_SIZE);
+        this.btnY = Math.min(Math.max(0, y), this.scrH - EXIT_BTN_SIZE);
+      }
+    }).catch(() => {});
+  }
+
+  private saveBtnPos(): void {
+    preferences.getPreferences(getContext(this), EXIT_BTN_PREF_FILE).then((prefs: preferences.Preferences) => {
+      prefs.putSync(EXIT_BTN_PREF_X, this.btnX);
+      prefs.putSync(EXIT_BTN_PREF_Y, this.btnY);
+      prefs.flush();
+    }).catch(() => {});
+  }
+
+  private onExitBtnTouch(ev: TouchEvent): void {
+    if (ev.type === TouchType.Down) {
+      const t = ev.touches[0];
+      if (t) {
+        this.startX = t.windowX;
+        this.startY = t.windowY;
+      }
+      this.startBtnX = this.btnX;
+      this.startBtnY = this.btnY;
+      this.dragMoved = false;
+    } else if (ev.type === TouchType.Move) {
+      const t = ev.touches[0];
+      if (t) {
+        if (!this.dragMoved &&
+          (Math.abs(t.windowX - this.startX) > EXIT_DRAG_THRESHOLD ||
+            Math.abs(t.windowY - this.startY) > EXIT_DRAG_THRESHOLD)) {
+          this.dragMoved = true;
+        }
+        if (this.dragMoved) {
+          this.btnX = Math.min(Math.max(0, this.startBtnX + (t.windowX - this.startX)),
+            this.scrW - EXIT_BTN_SIZE);
+          this.btnY = Math.min(Math.max(0, this.startBtnY + (t.windowY - this.startY)),
+            this.scrH - EXIT_BTN_SIZE);
+        }
+      }
+    } else if (ev.type === TouchType.Up || ev.type === TouchType.Cancel) {
+      if (!this.dragMoved) {
+        WineWindowManager.getInstance().recoverDesktopWindow();
+      } else {
+        this.saveBtnPos();
+      }
+      this.dragMoved = false;
+    }
+  }
 
   build() {
     Stack() {
       DesktopLayer({ floating: false })
 
-      // 顶部 hover 控制条 (反色: 白底黑字, 与黑色桌面形成反差):
-      // 未 hover 只占 24vp 透明热区, hover 后展开半透明白控制条。
-      Column() {
-        Row({ space: 8 }) {
-          Button('—')
-            .height(28).borderRadius(6).fontSize(16).fontColor('#000000')
-            .backgroundColor('#FFFFFF')
-            .onClick(() => { WineWindowManager.getInstance().minimizeDesktopWindow(); })
-          Button('还原')
-            .height(28).borderRadius(6).fontSize(13).fontColor('#000000')
-            .backgroundColor('#FFFFFF')
-            .onClick(() => { WineWindowManager.getInstance().restoreDesktopWindow(); })
-          Button('✕')
-            .height(28).borderRadius(6).fontSize(14).fontColor('#FFFFFF')
-            .backgroundColor('#D94848')
-            .onClick(() => { WineWindowManager.getInstance().closeDesktopWindow(); })
+      if (this.immersive) {
+        Stack() {
+          SymbolGlyph($r('sys.symbol.full_screen_fill'))
+            .fontSize(18)
+            .fontColor([Color.White])
         }
-        .width('100%')
-        .justifyContent(FlexAlign.End)
-        .padding({ right: 12, top: 6, bottom: 6 })
-        .opacity(this.hoverMenu ? 1 : 0)
+        .width(EXIT_BTN_SIZE)
+        .height(EXIT_BTN_SIZE)
+        .borderRadius(EXIT_BTN_SIZE / 2)
+        .backgroundColor('#33000000')
+        .border({ width: 1, color: '#66FFFFFF', style: BorderStyle.Solid })
+        .position({ x: this.btnX, y: this.btnY })
+        .onTouch((ev: TouchEvent) => this.onExitBtnTouch(ev))
       }
-      .width('100%')
-      .height(this.hoverMenu ? 52 : 24)
-      .backgroundColor(this.hoverMenu ? '#E6FFFFFF' : 'transparent')
-      .align(Alignment.Top)
-      .zIndex(10)
-      .onHover((isHover: boolean) => { this.hoverMenu = isHover; })
     }
-    .width('100%').height('100%')
+    .width('100%')
+    .height('100%')
+    .backgroundColor('#000000')
   }
 }

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -7,6 +7,7 @@ import { BusinessError } from '@kit.BasicServicesKit';
 import testNapi from 'libentry.so';
 import { AppSearchBar } from '../components/SearchBar';
 import { AppCard } from '../components/AppCard';
+import { FileBrowserView } from '../components/FileBrowserView';
 import { BreakpointSystem, BreakpointType } from '../common/BreakpointSystem';
 import {
   AppDescriptor,
@@ -712,8 +713,12 @@ struct Index {
     }
   }
 
+  private catalogCardViewMode(): ViewMode {
+    return this.settings.viewMode === ViewMode.FILES ? ViewMode.GRID : this.settings.viewMode;
+  }
+
   private gridColumns(): string {
-    if (this.settings.viewMode === ViewMode.COMPACT) return '1fr';
+    if (this.catalogCardViewMode() === ViewMode.COMPACT) return '1fr';
     // VintagePomelo keeps cover cards in two columns on phones. A single
     // flexible column makes one icon fill almost the entire compact window.
     if (this.isPhoneLandscape()) return '1fr 1fr';
@@ -755,8 +760,8 @@ struct Index {
     // Grid can under-measure an auto-height card while a narrow two-column
     // layout is settling. Reserve the cover, fixed title row and shadow inset
     // explicitly so the following row can never paint over this card.
-    if (this.settings.viewMode === ViewMode.COMPACT) return 120;
-    const coverHeight = this.settings.viewMode === ViewMode.LARGE ? 196 : 120;
+    if (this.catalogCardViewMode() === ViewMode.COMPACT) return 120;
+    const coverHeight = this.catalogCardViewMode() === ViewMode.LARGE ? 196 : 120;
     return coverHeight + 71 + 16;
   }
 
@@ -907,18 +912,21 @@ struct Index {
       buttons: [
         { text: (this.settings.viewMode === ViewMode.GRID ? '✓ ' : '') + '网格封面', color: $r('sys.color.ohos_id_color_text_primary') },
         { text: (this.settings.viewMode === ViewMode.COMPACT ? '✓ ' : '') + '紧凑列表', color: $r('sys.color.ohos_id_color_text_primary') },
-        { text: (this.settings.viewMode === ViewMode.LARGE ? '✓ ' : '') + '大封面', color: $r('sys.color.ohos_id_color_text_primary') }
+        { text: (this.settings.viewMode === ViewMode.LARGE ? '✓ ' : '') + '大封面', color: $r('sys.color.ohos_id_color_text_primary') },
+        { text: (this.settings.viewMode === ViewMode.FILES ? '✓ ' : '') + '文件浏览', color: $r('sys.color.ohos_id_color_text_primary') }
       ]
     }).then((result) => {
       if (result.index === 0) this.setViewMode(ViewMode.GRID);
       else if (result.index === 1) this.setViewMode(ViewMode.COMPACT);
       else if (result.index === 2) this.setViewMode(ViewMode.LARGE);
+      else if (result.index === 3) this.setViewMode(ViewMode.FILES);
     }).catch(() => {});
   }
 
   private phoneViewModeIcon(): Resource {
     if (this.settings.viewMode === ViewMode.COMPACT) return $r('sys.symbol.list_bullet');
     if (this.settings.viewMode === ViewMode.LARGE) return $r('sys.symbol.rectangle_grid_1x2');
+    if (this.settings.viewMode === ViewMode.FILES) return $r('sys.symbol.folder');
     return $r('sys.symbol.square_grid_2x2');
   }
 
@@ -1077,6 +1085,8 @@ struct Index {
               .width(48).height(48).backgroundColor(this.settings.viewMode === ViewMode.COMPACT ? $r('app.color.selected_background') : $r('app.color.search_background')).onClick(() => this.setViewMode(ViewMode.COMPACT))
             Button({ type: ButtonType.Circle }) { SymbolGlyph($r('sys.symbol.rectangle_grid_1x2')).fontSize(17).fontColor([$r('app.color.text_primary')]) }
               .width(48).height(48).backgroundColor(this.settings.viewMode === ViewMode.LARGE ? $r('app.color.selected_background') : $r('app.color.search_background')).onClick(() => this.setViewMode(ViewMode.LARGE))
+            Button({ type: ButtonType.Circle }) { SymbolGlyph($r('sys.symbol.folder')).fontSize(17).fontColor([$r('app.color.text_primary')]) }
+              .width(48).height(48).backgroundColor(this.settings.viewMode === ViewMode.FILES ? $r('app.color.selected_background') : $r('app.color.search_background')).onClick(() => this.setViewMode(ViewMode.FILES))
           }
           .id('library-view-modes')
           // Keep the complete system-reported title-button area. PC window
@@ -1136,8 +1146,8 @@ struct Index {
         .constraintSize({ minHeight: this.isPhone() ? this.phoneGridItemMinHeight() : 0 })
       }, (app: AppDescriptor): string => app.id)
     }
-    .columnsTemplate(this.settings.viewMode === ViewMode.COMPACT ? this.compactGridColumns() :
-      (this.settings.viewMode === ViewMode.LARGE ? this.largeGridColumns() : this.gridColumns()))
+    .columnsTemplate(this.catalogCardViewMode() === ViewMode.COMPACT ? this.compactGridColumns() :
+      (this.catalogCardViewMode() === ViewMode.LARGE ? this.largeGridColumns() : this.gridColumns()))
     .columnsGap(8)
     .rowsGap(this.isPhone() ? 8 : 4)
     .width('100%')
@@ -1147,7 +1157,7 @@ struct Index {
   private CatalogCard(app: AppDescriptor) {
     AppCard({
       app: app,
-      viewMode: this.settings.viewMode,
+      viewMode: this.catalogCardViewMode(),
       running: this.runningAppIds.has(app.id),
       useGlassEffect: this.settings.useGlassEffect,
       narrowPhone: this.isPhone(),
@@ -1227,7 +1237,9 @@ struct Index {
   @Builder
   private WindowsRefreshContent() {
     Refresh({ refreshing: $$this.refreshing }) {
-      if (this.scanning) {
+      if (this.settings.viewMode === ViewMode.FILES) {
+        FileBrowserView()
+      } else if (this.scanning) {
         Row({ space: 10 }) {
           LoadingProgress().width(20).height(20)
           Text('正在扫描应用目录…').fontColor($r('app.color.text_secondary'))

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -18,6 +18,7 @@ import {
   GlobalSettings,
   LaunchKind,
   RuntimeSession,
+  ScreenOrientationSetting,
   ThemeMode,
   ViewMode,
   normalizeLaunchPath,
@@ -38,9 +39,10 @@ import { InputProfileService } from '../service/InputProfileService';
 import { WineEngineBlockingOverlay } from '../components/WineEngineBlockingOverlay';
 import { DesktopLayer } from '../components/DesktopLayer';
 import { DeviceCapabilityPolicy } from '../common/DeviceCapabilityPolicy';
-import { LengthMetrics, display, window } from '@kit.ArkUI';
+import { LengthMetrics, window } from '@kit.ArkUI';
 import deviceInfo from '@ohos.deviceInfo';
 import {
+  applyDesktopFullscreenShell,
   applyStatusOnlyImmersiveShell,
   getMiniTitleContentTopInset,
   getStatusOnlyWindowInsets,
@@ -84,8 +86,9 @@ interface ScrollOffsetSnapshot {
   yOffset: number;
 }
 
-// 浮窗模式: 桌面小浮窗宽度 (vp), 高度按屏幕比例折算 (main_ui 同构)
+// 浮窗模式: 小窗始终按横屏桌面比例显示 (手机竖持时也是横条，点开再转横屏全屏)
 const FLOATING_W: number = 320;
+const FLOATING_W_PHONE: number = 248;
 
 @Entry
 @Component
@@ -140,9 +143,12 @@ struct Index {
   private floatPanStartX: number = 0;
   private floatPanStartY: number = 0;
   private transitioning: boolean = false;
+  /** 浮窗全屏或缩回未竖屏稳定前隐藏库页 HDS/底栏，避免标题盖住按键。 */
+  @State private libraryChromeReady: boolean = true;
   private screenW: number = 0;
   private screenH: number = 0;
   @State private floatH: number = 135;
+  private floatPosPlaced: boolean = false;
 
   private isPhone(): boolean {
     return DeviceCapabilityPolicy.isPhoneDevice() || this.breakpoint === 'xs' || this.breakpoint === 'sm';
@@ -167,28 +173,264 @@ struct Index {
     return WineWindowManager.getInstance().getDesktopRootId() > 0;
   }
 
-  // 缩放过渡动画: 显式动画包裹 launcherVisible 翻转, 宽/高/位置/圆角一次过渡
-  private setLauncherVisible(v: boolean): void {
+  private floatingWidth(): number {
+    const preferred = DeviceCapabilityPolicy.isPhoneDevice() ? FLOATING_W_PHONE : FLOATING_W;
+    const maxW = Math.max(160, this.screenW - 24);
+    return Math.min(preferred, maxW);
+  }
+
+  /** 与 Wine 横屏桌面同比例，避免竖持手机把小窗拉成竖屏。 */
+  private floatingHeight(): number {
+    const longSide = Math.max(this.screenW, this.screenH);
+    const shortSide = Math.min(this.screenW, this.screenH);
+    const ratio = (longSide > 0 && shortSide > 0) ? longSide / shortSide : 16 / 9;
+    return Math.max(88, Math.round(this.floatingWidth() / ratio));
+  }
+
+  private floatTopReserve(): number {
+    return Math.max(12, this.titleContentTopInsetVp);
+  }
+
+  private floatBottomReserve(): number {
+    if (this.isPhone()) {
+      return this.isPhoneLandscape() ? 72 : 80;
+    }
+    return Math.max(12, this.navBarInsetVp);
+  }
+
+  private floatMinX(): number {
+    return 0;
+  }
+
+  private floatMinY(): number {
+    return this.floatTopReserve();
+  }
+
+  private floatMaxX(): number {
+    return Math.max(this.floatMinX(), this.screenW - this.floatingWidth());
+  }
+
+  private floatMaxY(): number {
+    return Math.max(this.floatMinY(), this.screenH - this.floatingHeight() - this.floatBottomReserve());
+  }
+
+  private clampFloatPos(): void {
+    this.floatPosX = Math.min(Math.max(this.floatPosX, this.floatMinX()), this.floatMaxX());
+    this.floatPosY = Math.min(Math.max(this.floatPosY, this.floatMinY()), this.floatMaxY());
+  }
+
+  private placeDefaultFloatPos(): void {
+    this.floatH = this.floatingHeight();
+    this.floatPosX = Math.max(12, this.screenW - this.floatingWidth() - 12);
+    this.floatPosY = this.floatMaxY();
+    this.clampFloatPos();
+  }
+
+  private libraryViewportReady(): boolean {
+    if (this.screenW <= 0 || this.screenH <= 0) {
+      return false;
+    }
+    // 手机缩回尚未完成时 viewport 可能仍是横屏；此时 clamp 会把竖屏坐标压坏。
+    if (this.transitioning && DeviceCapabilityPolicy.isPhoneDevice() && this.screenW > this.screenH) {
+      return false;
+    }
+    return true;
+  }
+
+  private ensureFloatPos(): void {
+    if (!this.libraryViewportReady()) {
+      return;
+    }
+    this.floatH = this.floatingHeight();
+    if (!this.floatPosPlaced) {
+      this.placeDefaultFloatPos();
+      this.floatPosPlaced = true;
+      return;
+    }
+    this.clampFloatPos();
+  }
+
+  private resolveMainWindow(): window.Window | null {
+    return WineWindowManager.getInstance().getMainWindow();
+  }
+
+  private animateLauncherVisible(v: boolean, onFinish?: () => void, keepTransitioning: boolean = false): void {
     this.transitioning = true;
     this.getUIContext().animateTo({
       duration: 300,
       curve: Curve.LinearOutSlowIn,
-      onFinish: () => { this.transitioning = false; }
+      onFinish: () => {
+        if (!keepTransitioning) {
+          this.transitioning = false;
+        }
+        if (onFinish) {
+          onFinish();
+        }
+      }
     }, () => {
       this.launcherVisible = v;
     });
   }
 
-  private onLauncherVisibleChange(): void {
-    // 悬浮窗态 → WineWindowManager 跳过 root resize (桌面分辨率保持全屏)
-    WineWindowManager.getInstance().setDesktopLauncherVisible(this.launcherVisible);
-    // 全屏态创建虚拟输入 overlay, 悬浮窗态隐藏
-    if (this.launcherVisible) {
-      InputOverlayWindowCoordinator.getInstance().detach('floating-shrink').catch(() => {});
-    } else {
-      this.attachFloatingOverlay();
+  private libraryChromeVisible(): boolean {
+    if (!this.showDesktopLayer()) {
+      return true;
     }
-    // 同步全屏态标志给 overlay (home 按钮显示)
+    if (!this.launcherVisible) {
+      return false;
+    }
+    return this.libraryChromeReady;
+  }
+
+  // 缩放过渡动画: 显式动画包裹 launcherVisible 翻转, 宽/高/位置/圆角一次过渡
+  // 放大: 锁横屏 → 动画 → 结束后再 show overlay。缩小: 先藏 overlay, 立刻锁竖屏。
+  private setLauncherVisible(v: boolean): void {
+    if (this.transitioning) {
+      return;
+    }
+    if (!v) {
+      if (!this.launcherVisible) {
+        return;
+      }
+      this.transitioning = true;
+      this.libraryChromeReady = false;
+      this.prepareFloatingFullscreen().then((): void => {
+        this.expandFloatingDesktop();
+      }).catch((): void => {
+        this.expandFloatingDesktop();
+      });
+      return;
+    }
+    if (this.launcherVisible && this.libraryChromeReady) {
+      return;
+    }
+    this.shrinkFloatingDesktop();
+  }
+
+  private expandFloatingDesktop(): void {
+    const manager = WineWindowManager.getInstance();
+    manager.setFloatingLayoutAnimating(true);
+    let finished = false;
+    const finishExpand = (): void => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      manager.setFloatingLayoutAnimating(false);
+      manager.setDesktopLauncherVisible(false);
+      this.showFloatingOverlay().then((): void => {
+        this.transitioning = false;
+      }).catch((): void => {
+        this.transitioning = false;
+      });
+    };
+    this.animateLauncherVisible(false, finishExpand, true);
+    setTimeout((): void => {
+      if (!finished) {
+        finishExpand();
+      }
+    }, 800);
+  }
+
+  private shrinkFloatingDesktop(): void {
+    this.transitioning = true;
+    this.libraryChromeReady = false;
+    const manager = WineWindowManager.getInstance();
+    manager.setDesktopLauncherVisible(true);
+    manager.setFloatingLayoutAnimating(true);
+    void this.runShrinkSequence(manager).catch((): void => {
+      this.ensureFloatPos();
+      this.transitioning = false;
+      manager.setFloatingLayoutAnimating(false);
+      this.libraryChromeReady = true;
+      this.launcherVisible = true;
+    });
+  }
+
+  private async runShrinkSequence(manager: WineWindowManager): Promise<void> {
+    try {
+      await this.hideFloatingOverlay();
+    } catch (_) {
+    }
+    let animDone = false;
+    let orientDone = false;
+    const finishShrink = (): void => {
+      if (!animDone || !orientDone) {
+        return;
+      }
+      this.ensureFloatPos();
+      this.transitioning = false;
+      manager.setFloatingLayoutAnimating(false);
+      this.libraryChromeReady = true;
+      this.launcherVisible = true;
+    };
+    this.animateLauncherVisible(true, (): void => {
+      animDone = true;
+      finishShrink();
+    }, true);
+    setTimeout((): void => {
+      if (!animDone) {
+        animDone = true;
+        finishShrink();
+      }
+    }, 800);
+    try {
+      await this.restoreLibraryOrientation();
+    } catch (_) {
+    }
+    orientDone = true;
+    finishShrink();
+  }
+
+  private async prepareFloatingFullscreen(): Promise<void> {
+    const win = this.resolveMainWindow();
+    if (!win) {
+      return;
+    }
+    // 库页 status-only 壳会把状态栏/系统标题留在窗口上。放大前先换成
+    // 桌面全屏壳；转屏后再刷一次，避免方向事务把系统栏拉回来。
+    await applyDesktopFullscreenShell(win);
+    if (DeviceCapabilityPolicy.isPhoneDevice()) {
+      const setting = this.settings.desktopOrientation ?? ScreenOrientationSetting.SENSOR_LANDSCAPE;
+      await DeviceCapabilityPolicy.applyDesktopOrientation(win, setting, 'Index-float');
+      await DeviceCapabilityPolicy.waitForRequestedOrientation(win, setting, 'Index-float');
+      await applyDesktopFullscreenShell(win);
+      WineWindowManager.getInstance().prepareOutputForOrientation(setting);
+    }
+  }
+
+  private async restoreLibraryOrientation(): Promise<void> {
+    const win = this.resolveMainWindow();
+    if (!win) {
+      return;
+    }
+    if (DeviceCapabilityPolicy.isPhoneDevice()) {
+      await DeviceCapabilityPolicy.applyPortraitOrientation(win, 'Index-float');
+      await DeviceCapabilityPolicy.waitForRequestedOrientation(win, ScreenOrientationSetting.PORTRAIT,
+        'Index-float');
+      DeviceCapabilityPolicy.enableSensorRotation(win, 'Index-float');
+    }
+    await this.restoreLibraryWindowShell(win);
+  }
+
+  private async restoreLibraryWindowShell(win: window.Window): Promise<void> {
+    try {
+      await win.setWindowDecorVisible(false);
+    } catch (_) {
+    }
+    await applyStatusOnlyImmersiveShell(win);
+    if (DeviceCapabilityPolicy.usesManagedWineWindows()) {
+      try {
+        win.setWindowDecorHeight(48);
+        win.setWindowTitleMoveEnabled(true);
+      } catch (_) {
+      }
+    }
+    this.startWindowInsetObserver(win);
+    this.refreshPageInsets(win);
+  }
+
+  private onLauncherVisibleChange(): void {
     AppStorage.setOrCreate('desktopFloatingFullscreen', !this.launcherVisible);
   }
 
@@ -211,33 +453,31 @@ struct Index {
     AppStorage.setOrCreate('desktopEnterFullscreen', false);
   }
 
-  private attachFloatingOverlay(): void {
-    const stage = WineWindowManager.getInstance().getMainWindowStage();
-    if (!stage) return;
-    const rootId = WineWindowManager.getInstance().getDesktopRootId();
-    if (rootId <= 0) return;
-    window.getLastWindow(this.context).then((win: window.Window) => {
-      InputOverlayWindowCoordinator.getInstance().attach(
-        stage, win, 'desktop-' + rootId, DisplayMode.DESKTOP, rootId,
-        this.settings.desktopInputProfileId || 'default', this.settings.showVirtualControls,
-        this.settings.controlOpacity, this.settings.virtualInputEnabled, true).catch(() => {});
-    }).catch(() => {});
+  private async hideFloatingOverlay(): Promise<void> {
+    AppStorage.setOrCreate('desktopFloatingFullscreen', false);
+    await InputOverlayWindowCoordinator.getInstance().setVisible(false);
   }
 
-  private initFloatPos(): void {
-    // 用屏幕尺寸 (aboutToAppear 时 viewport 可能为 0)
-    try {
-      const d = display.getDefaultDisplaySync();
-      this.screenW = px2vp(d.width);
-      this.screenH = px2vp(d.height);
-    } catch (_) {
-      this.screenW = 640;
-      this.screenH = 400;
+  private async showFloatingOverlay(): Promise<void> {
+    AppStorage.setOrCreate('desktopFloatingFullscreen', true);
+    await this.attachFloatingOverlay();
+  }
+
+  private async attachFloatingOverlay(): Promise<void> {
+    const manager = WineWindowManager.getInstance();
+    const stage = manager.getMainWindowStage();
+    const win = manager.getMainWindow();
+    if (!stage || !win) {
+      return;
     }
-    // 悬浮窗高度随屏幕比例折算: 与桌面帧比例一致, 消除 letterbox 黑边
-    this.floatH = Math.round(FLOATING_W * this.screenH / this.screenW);
-    this.floatPosX = this.screenW - FLOATING_W - 12;
-    this.floatPosY = 80;
+    const rootId = manager.getDesktopRootId();
+    if (rootId <= 0) {
+      return;
+    }
+    await InputOverlayWindowCoordinator.getInstance().attach(
+      stage, win, 'desktop-' + rootId, DisplayMode.DESKTOP, rootId,
+      this.settings.desktopInputProfileId || 'default', this.settings.showVirtualControls,
+      this.settings.controlOpacity, this.settings.virtualInputEnabled, true);
   }
 
   private usesDarkAppearance(): boolean {
@@ -384,7 +624,6 @@ struct Index {
     };
     WineEngineService.getInstance().subscribe(this.engineCallback);
     this.refreshTimer = setInterval(() => this.refreshRunningState(), 1500);
-    this.initFloatPos();
   }
 
   aboutToDisappear(): void {
@@ -406,7 +645,9 @@ struct Index {
     } else {
       this.refreshRunningState();
     }
-    void this.applyPageWindowShell();
+    if (!(this.showDesktopLayer() && !this.launcherVisible)) {
+      void this.applyPageWindowShell();
+    }
   }
 
   onPageHide(): void {
@@ -441,7 +682,10 @@ struct Index {
 
   private async applyPageWindowShell(): Promise<void> {
     try {
-      const pageWindow = await window.getLastWindow(this.context);
+      const pageWindow = this.resolveMainWindow();
+      if (!pageWindow) {
+        return;
+      }
       await applyStatusOnlyImmersiveShell(pageWindow);
       this.startWindowInsetObserver(pageWindow);
     } catch (_) {
@@ -455,6 +699,9 @@ struct Index {
     const insets = getStatusOnlyWindowInsets(pageWindow);
     this.statusBarHeightVp = insets.top;
     this.navBarInsetVp = insets.bottom;
+    if (this.launcherVisible && !this.transitioning) {
+      this.ensureFloatPos();
+    }
   }
 
   private startWindowInsetObserver(pageWindow: window.Window): void {
@@ -1238,7 +1485,10 @@ struct Index {
   private WindowsRefreshContent() {
     Refresh({ refreshing: $$this.refreshing }) {
       if (this.settings.viewMode === ViewMode.FILES) {
-        FileBrowserView()
+        FileBrowserView({
+          topInsetVp: this.isPhone() ? this.phoneTitleBarScrollInset() : 0,
+          bottomInsetVp: this.isPhone() ? this.phoneBottomInset() : 0
+        })
       } else if (this.scanning) {
         Row({ space: 10 }) {
           LoadingProgress().width(20).height(20)
@@ -1361,6 +1611,7 @@ struct Index {
     .width('100%')
     .height(this.isPhoneLandscape() ? 72 : 80)
     .id('library-bottom-bar')
+    .visibility(this.libraryChromeVisible() ? Visibility.Visible : Visibility.None)
   }
 
   @Builder
@@ -1457,7 +1708,7 @@ struct Index {
           .opacity(0.72)
           .hitTestBehavior(HitTestMode.None)
           // 浮窗模式全屏态: 桌面铺满, 隐藏启动器背景
-          .visibility(this.showDesktopLayer() && !this.launcherVisible ? Visibility.Hidden : Visibility.Visible)
+          .visibility(this.libraryChromeVisible() ? Visibility.Visible : Visibility.None)
           .id('library-page-background')
       }
       Row() {
@@ -1473,8 +1724,7 @@ struct Index {
       .width('100%')
       .height('100%')
       .padding({ top: this.isPhone() ? 0 : this.statusBarHeightVp + 16 })
-      // 浮窗模式全屏态: 隐藏启动器 (main_ui 语义), 桌面铺满当前画面不叠加
-      .visibility(this.showDesktopLayer() && !this.launcherVisible ? Visibility.Hidden : Visibility.Visible)
+      .visibility(this.libraryChromeVisible() ? Visibility.Visible : Visibility.None)
       if (this.isPhone()) {
         this.PhoneNavigation()
       }
@@ -1491,7 +1741,7 @@ struct Index {
               .width('100%').justifyContent(FlexAlign.Center)
               .padding({ top: 3, bottom: 3 })
               .backgroundColor('#66000000')
-              .position({ x: 0, y: this.floatH - 26 })
+              .position({ x: 0, y: this.floatingHeight() - 26 })
               .hitTestBehavior(HitTestMode.None)
             }
             .width('100%').height('100%')
@@ -1504,17 +1754,17 @@ struct Index {
                 })
                 .onActionUpdate((ev: GestureEvent) => {
                   if (this.transitioning) return;
-                  const maxX = Math.max(this.screenW - FLOATING_W, 0);
-                  const maxY = Math.max(this.screenH - this.floatH, 0);
-                  this.floatPosX = Math.min(Math.max(this.floatPanStartX + ev.offsetX, 0), maxX);
-                  this.floatPosY = Math.min(Math.max(this.floatPanStartY + ev.offsetY, 0), maxY);
+                  this.floatPosX = Math.min(Math.max(this.floatPanStartX + ev.offsetX, this.floatMinX()),
+                    this.floatMaxX());
+                  this.floatPosY = Math.min(Math.max(this.floatPanStartY + ev.offsetY, this.floatMinY()),
+                    this.floatMaxY());
                 })
             )
             .hitTestBehavior(HitTestMode.Block)
           }
         }
-        .width(this.launcherVisible ? FLOATING_W : '100%')
-        .height(this.launcherVisible ? this.floatH : '100%')
+        .width(this.launcherVisible ? this.floatingWidth() : '100%')
+        .height(this.launcherVisible ? this.floatingHeight() : '100%')
         .position(this.launcherVisible ? { x: this.floatPosX, y: this.floatPosY } : { x: 0, y: 0 })
         .borderRadius(this.launcherVisible ? 12 : 0)
         .clip(true)
@@ -1529,6 +1779,13 @@ struct Index {
     .onAreaChange((_oldValue: Area, area: Area): void => {
       this.viewportWidth = area.width as number;
       this.viewportHeight = area.height as number;
+      if (this.viewportWidth > 0 && this.viewportHeight > 0) {
+        this.screenW = this.viewportWidth;
+        this.screenH = this.viewportHeight;
+        if (this.launcherVisible && !this.transitioning) {
+          this.ensureFloatPos();
+        }
+      }
       BreakpointSystem.updateFromWidth(this.viewportWidth);
     })
   }

--- a/entry/src/main/ets/pages/InputLayoutEditor.ets
+++ b/entry/src/main/ets/pages/InputLayoutEditor.ets
@@ -10,6 +10,7 @@ import {
   InputBindingKind,
   InputProfile,
   ThemeMode,
+  cloneControlElement,
   cloneInputProfile,
   createControlElement,
   createDefaultInputProfile,
@@ -142,7 +143,7 @@ struct InputLayoutEditor {
     this.resumeWineAbility();
   }
 
-  /** 绘制编辑参考网格：20px 细线 + 80px 加粗线，高密度便于对齐。 */
+  /** 绘制编辑参考网格：20vp 细线 + 80vp 加粗线。Canvas 默认单位是 vp。 */
   private drawEditorGrid(): void {
     if (this.previewW <= 0 || this.previewH <= 0) {
       hilog.info(DOMAIN, 'InputLayoutEditor', 'drawEditorGrid skip w=%{public}d h=%{public}d',
@@ -328,27 +329,20 @@ struct InputLayoutEditor {
   }
 
   private withElement(element: ControlElement, patch: ElementPatch): ControlElement {
-    return {
-      id: element.id,
-      type: element.type,
-      shape: patch.shape ?? element.shape,
-      x: patch.x ?? element.x,
-      y: patch.y ?? element.y,
-      scale: patch.scale ?? element.scale,
-      widthScale: patch.widthScale ?? element.widthScale ?? 1,
-      heightScale: element.heightScale ?? 1,
-      panelWidthRatio: element.panelWidthRatio,
-      panelHeightRatio: element.panelHeightRatio,
-      opacity: patch.opacity ?? element.opacity,
-      bindings: patch.bindings ?? element.bindings,
-      toggleSwitch: patch.toggleSwitch ?? element.toggleSwitch,
-      text: patch.text ?? element.text,
-      iconId: element.iconId,
-      visible: element.visible,
-      keyList: patch.keyList ?? element.keyList,
-      orientation: patch.orientation ?? element.orientation ?? 'vertical',
-      outputMode: patch.outputMode ?? element.outputMode ?? 'keys'
-    };
+    const next = cloneControlElement(element);
+    if (patch.x !== undefined) next.x = patch.x;
+    if (patch.y !== undefined) next.y = patch.y;
+    if (patch.scale !== undefined) next.scale = patch.scale;
+    if (patch.widthScale !== undefined) next.widthScale = patch.widthScale;
+    if (patch.text !== undefined) next.text = patch.text;
+    if (patch.shape !== undefined) next.shape = patch.shape;
+    if (patch.toggleSwitch !== undefined) next.toggleSwitch = patch.toggleSwitch;
+    if (patch.opacity !== undefined) next.opacity = patch.opacity;
+    if (patch.bindings !== undefined) next.bindings = patch.bindings;
+    if (patch.keyList !== undefined) next.keyList = patch.keyList;
+    if (patch.orientation !== undefined) next.orientation = patch.orientation;
+    if (patch.outputMode !== undefined) next.outputMode = patch.outputMode;
+    return next;
   }
 
   private elementPixelWidth(element: ControlElement): number {
@@ -357,6 +351,10 @@ struct InputLayoutEditor {
     }
     const viewportScale = this.previewControlScale();
     const widthScale = element.widthScale ?? 1;
+    const keyWidthRatio = element.keyWidthRatio;
+    if (keyWidthRatio !== undefined && keyWidthRatio > 0) {
+      return this.previewW * keyWidthRatio * (element.scale ?? 1) * widthScale;
+    }
     if (element.type === ControlElementType.TRACKPAD) {
       return 150 * (element.scale ?? 1) * widthScale * viewportScale;
     }
@@ -375,6 +373,10 @@ struct InputLayoutEditor {
     }
     const viewportScale = this.previewControlScale();
     const heightScale = element.heightScale ?? 1;
+    const keyHeightRatio = element.keyHeightRatio;
+    if (keyHeightRatio !== undefined && keyHeightRatio > 0) {
+      return this.previewH * keyHeightRatio * (element.scale ?? 1) * heightScale;
+    }
     if (element.type === ControlElementType.TRACKPAD) {
       return 100 * (element.scale ?? 1) * heightScale * viewportScale;
     }

--- a/entry/src/main/ets/pages/InputOverlay.ets
+++ b/entry/src/main/ets/pages/InputOverlay.ets
@@ -855,6 +855,7 @@ struct InputOverlayPage {
           controlBarPositionX: this.settings.controlBarPositionX,
           controlBarPositionY: this.settings.controlBarPositionY,
           touchpadMode: this.touchpadMode,
+          showCursor: this.settings.virtualMouseConfig.showCursor,
           onOpenLayoutEditor: (): void => { this.openInputEditor('input-layout'); },
           onOpenKeyMappingEditor: (): void => { this.openInputEditor('key-mapping'); },
           onToggleHostKeyboard: (): void => { this.toggleHostKeyboard(); },

--- a/entry/src/main/ets/pages/InputOverlay.ets
+++ b/entry/src/main/ets/pages/InputOverlay.ets
@@ -4,8 +4,12 @@ import {
   EVDEV_KEY_BACKSPACE,
   EVDEV_KEY_ENTER,
   EVDEV_KEY_LEFTSHIFT,
+  OH2EVDEV,
   asciiToEvdevKey
 } from '../common/KeyMap';
+import { InputRouter } from '../service/InputRouter';
+import { GamepadManager } from '../service/GamepadManager';
+import { WineWindowManager } from '../service/WineWindowManager';
 import {
   DisplayMode,
   GlobalSettings,
@@ -107,6 +111,8 @@ struct InputOverlayPage {
   private static readonly TOUCHPAD_TAP_CONFIRM_MS: number = 150;
   private mouseLeftActive: boolean = false;
   private mouseLeftReleaseTimer: number = -1;
+  private lastEnterDownTs: number = 0;
+  private static readonly ENTER_SYNTH_WINDOW_MS: number = 1000;
 
   aboutToAppear(): void {
     this.listener = (snapshot: InputOverlaySnapshot): void => {
@@ -443,14 +449,45 @@ struct InputOverlayPage {
       this.hostImeReseedPending = true;
       this.hostImeBuffer = InputOverlayPage.HOST_SENTINEL;
       this.hostImeContent = InputOverlayPage.HOST_SENTINEL;
-      focusController.requestFocus('wine-host-keyboard-input');
+      // TextInput 刚从 focusable(false) 切过来, 等一帧再抢焦点, 否则 requestFocus 落空。
+      setTimeout((): void => {
+        try {
+          this.getUIContext().getFocusController().requestFocus('wine-host-keyboard-input');
+        } catch (_) {
+        }
+      }, 32);
     } else {
       focusController.clearFocus();
       testNapi.wineTextInputSetArmed(false);
       this.pendingHostCommit = '';
       this.hostImeBuffer = '';
       this.hostImeContent = '';
+      // overlay 子窗口无法直接 requestFocus 父窗 XComponent; DesktopLayer 监听此 token。
+      AppStorage.setOrCreate('wineDesktopKeyFocusToken', Date.now());
     }
+  }
+
+  /** 宿主键盘关闭时转发蓝牙/实体 KeyEvent; 打开时不拦截, 拼音走 TextInput/IME。 */
+  private handleHardwareKey(ev: KeyEvent): void {
+    if (this.hostKeyboardActive) return;
+    const rootId = WineWindowManager.getInstance().getDesktopRootId();
+    if (rootId <= 0) return;
+    ev.stopPropagation();
+    if (GamepadManager.getInstance().handleKey(ev.keyCode, ev.type === KeyType.Down)) return;
+    const code = OH2EVDEV[ev.keyCode] ?? 0;
+    if (code <= 0) return;
+    const pressed = ev.type === KeyType.Down;
+    if (InputRouter.getInstance().getActiveToplevel() <= 0) {
+      InputRouter.getInstance().setActiveToplevel(rootId);
+    }
+    if (code === EVDEV_KEY_ENTER) {
+      if (pressed) {
+        this.lastEnterDownTs = Date.now();
+      } else if (Date.now() - this.lastEnterDownTs > InputOverlayPage.ENTER_SYNTH_WINDOW_MS) {
+        InputRouter.getInstance().sendKey(EVDEV_KEY_ENTER, true);
+      }
+    }
+    InputRouter.getInstance().sendKey(code, pressed);
   }
 
   /** 哨兵保活: 程序性重填, onChange 按 oldContent→sentinel 识别并忽略。 */
@@ -831,7 +868,7 @@ struct InputOverlayPage {
       // 宿主键盘载体: 平时不可见/不参与命中, 聚焦后唤起系统输入法。
       TextInput({ placeholder: '', text: this.hostImeBuffer, controller: this.hostImeController })
         .id('wine-host-keyboard-input')
-        .focusable(true)
+        .focusable(this.hostKeyboardActive)
         .type(InputType.Normal)
         .enterKeyType(EnterKeyType.NEW_LINE)
         .width(40).height(40)
@@ -911,6 +948,7 @@ struct InputOverlayPage {
     .width('100%').height('100%')
     .backgroundColor('#00000000')
     .id('wine-input-overlay-page')
+    .onKeyEvent((ev: KeyEvent): void => this.handleHardwareKey(ev))
     .onAreaChange((_oldValue: Area, area: Area): void => {
       this.overlayW = area.width as number;
       this.overlayH = area.height as number;

--- a/entry/src/main/ets/pages/SystemSettings.ets
+++ b/entry/src/main/ets/pages/SystemSettings.ets
@@ -344,7 +344,9 @@ struct SystemSettingsPage {
     this.loadInputProfiles();
     this.loadApplicationVersion();
     this.loadGpuInfo();
-    this.renderMode = AppStorage.get<string>('winehua.render.mode') ?? 'auto';
+    this.renderMode = AppSettingsStore.getInstance().getRenderMode()
+      || AppStorage.get<string>('winehua.render.mode')
+      || 'auto';
   }
 
   onPageShow(): void {
@@ -470,10 +472,32 @@ struct SystemSettingsPage {
   }
 
   private resetPrefix(): void {
+    const preserve = this.settings.preserveUserDataOnReset;
     this.runEngineOperation('正在重置 Wine prefix，请勿退出应用…', async (): Promise<boolean> => {
       await AppSessionService.getInstance().resetPrefix();
       return true;
-    }, 'Wine 环境已重置');
+    }, preserve ? 'Wine 沙盒已重建，文档和注册表已还原' : 'Wine 环境已重置');
+  }
+
+  private setPreserveUserDataOnReset(value: boolean): void {
+    this.update(this.settings.defaultDisplayMode, this.settings.viewMode,
+      this.settings.useGlassEffect, this.settings.usePageBackground,
+      this.settings.showVirtualControls, this.settings.autoHideVirtualControls,
+      this.settings.controlOpacity, this.settings.gamepadDeadzone,
+      this.settings.outputScale, this.settings.themeMode,
+      this.settings.controlBarDirection, this.settings.virtualMouseConfig,
+      this.settings.desktopInputProfileId, this.settings.pageBackgroundUri,
+      this.settings.virtualInputEnabled, this.settings.desktopOrientation,
+      this.settings.controlBarPositionX, this.settings.controlBarPositionY,
+      this.settings.d3dRendererPreference, this.settings.desktopWindowMode,
+      this.settings.keepScreenOn, value);
+  }
+
+  private resetPrefixConfirmMessage(): string {
+    if (this.settings.preserveUserDataOnReset) {
+      return '将清空 Wine 沙盒并重装运行时，然后还原文档和注册表。损坏的系统目录会被重建。';
+    }
+    return '将删除当前 Wine prefix 中的全部数据，且无法撤销。';
   }
 
   private async exportLogs(): Promise<void> {
@@ -541,7 +565,8 @@ struct SystemSettingsPage {
       controlBarPositionY: number = this.settings.controlBarPositionY,
       d3dRendererPreference: D3DRendererPreference = this.settings.d3dRendererPreference,
       desktopWindowMode: DesktopWindowMode = this.settings.desktopWindowMode,
-      keepScreenOn: boolean = this.settings.keepScreenOn): void {
+      keepScreenOn: boolean = this.settings.keepScreenOn,
+      preserveUserDataOnReset: boolean = this.settings.preserveUserDataOnReset): void {
     const virtualInputChanged = this.settings.virtualInputEnabled !== virtualInputEnabled;
     this.settings = {
       defaultDisplayMode: mode,
@@ -565,7 +590,8 @@ struct SystemSettingsPage {
       controlOpacity: opacity,
       gamepadDeadzone: deadzone,
       outputScale: scale,
-      d3dRendererPreference: d3dRendererPreference
+      d3dRendererPreference: d3dRendererPreference,
+      preserveUserDataOnReset: preserveUserDataOnReset
     };
     GamepadManager.getInstance().setDeadzone(deadzone);
     WineWindowManager.getInstance().setOutputScalePercent(scale);
@@ -929,26 +955,24 @@ struct SystemSettingsPage {
   }
 
   /** 渲染模式: auto / dxvk_2_6 / dxvk_1_10 / virgl。
-   *  自动: DX11→DXVK 2.6 (GPU 不适配自动 1.10), D3D12→VKD3D, 渲染 VirGL 优先。
-   *  切换后自动重启引擎即时生效, 无需手动重启。 */
+   *  自动: DX11→DXVK 2.6 (GPU 不适配自动 1.10), D3D12→VKD3D。
+   *  写入 Preferences 后再重启引擎，避免下次冷启动回退 auto。 */
   private updateRenderMode(mode: string): void {
     const selected = mode === 'dxvk_2_6' || mode === 'dxvk_1_10' || mode === 'virgl' ? mode : 'auto';
-    const current = AppStorage.get<string>('winehua.render.mode') ?? 'auto';
+    const current = AppSettingsStore.getInstance().getRenderMode()
+      || AppStorage.get<string>('winehua.render.mode')
+      || 'auto';
     if (current === selected) return;
-    AppStorage.setOrCreate<string>('winehua.render.mode', selected);
-    this.renderMode = selected;   // 立即刷新按钮选中态
+    this.renderMode = selected;
     promptAction.showToast({ message: '渲染模式已切换，正在重启引擎…' });
-    this.restartEngine();
+    void AppSettingsStore.getInstance().setRenderMode(selected).then((): void => {
+      this.restartEngine();
+    });
   }
 
-  /** DXVK 版本: 1.10 (dxvk_legacy) / 2.6 (dxvk_modern_2_6, 含 VKD3D 实验 D3D12)。 */
+  /** DXVK 版本芯片与渲染模式共用同一持久化项。 */
   private updateDxvkVersion(version: string): void {
-    const selected = version === 'dxvk_modern_2_6' ? 'dxvk_modern_2_6' : 'dxvk_legacy';
-    const current = AppStorage.get<string>('winehua.dxvk.preference') ?? 'auto';
-    if (current === selected) return;
-    AppStorage.setOrCreate<string>('winehua.dxvk.preference', selected);
-    AppStorage.setOrCreate<string>('winehua.dxvk.backend', selected);
-    promptAction.showToast({ message: 'DXVK 版本已保存；重启 Wine 引擎后生效' });
+    this.updateRenderMode(version === 'dxvk_modern_2_6' ? 'dxvk_2_6' : 'dxvk_1_10');
   }
 
   private updateD3DRendererPreference(preference: D3DRendererPreference): void {
@@ -989,7 +1013,8 @@ struct SystemSettingsPage {
       controlOpacity: this.settings.controlOpacity,
       gamepadDeadzone: this.settings.gamepadDeadzone,
       outputScale: this.settings.outputScale,
-      d3dRendererPreference: this.settings.d3dRendererPreference
+      d3dRendererPreference: this.settings.d3dRendererPreference,
+      preserveUserDataOnReset: this.settings.preserveUserDataOnReset
     };
     void ThemeSettingsService.getInstance().update(this.settings);
     promptAction.showToast({ message: '兼容性预设已保存，新启动的程序生效' });
@@ -1361,20 +1386,17 @@ struct SystemSettingsPage {
   }
 
   private dxvkVersionActive(version: string): boolean {
-    return AppStorage.get<string>('winehua.dxvk.preference') === version;
-  }
-
-  /** 自动模式下按 GPU 解析出的 DXVK 版本, 用来同时高亮「自动」和实际后端。 */
-  private resolvedDxvkMode(): string {
-    return this.gpuSupportDxvk26 ? 'dxvk_2_6' : 'dxvk_1_10';
+    if (version === 'dxvk_modern_2_6') {
+      return this.renderMode === 'dxvk_2_6';
+    }
+    if (version === 'dxvk_legacy') {
+      return this.renderMode === 'dxvk_1_10';
+    }
+    return false;
   }
 
   private renderModeActive(mode: string): boolean {
-    if (this.renderMode === mode) return true;
-    if (this.renderMode === 'auto' && (mode === 'dxvk_2_6' || mode === 'dxvk_1_10')) {
-      return mode === this.resolvedDxvkMode();
-    }
-    return false;
+    return this.renderMode === mode;
   }
 
   @Builder
@@ -1823,7 +1845,7 @@ struct SystemSettingsPage {
               Text('全屏触摸板模式').fontSize(15).fontWeight(FontWeight.Medium).fontColor($r('app.color.text_primary')).width('100%')
               Text('从 Wine 画面右上角手指图标切换。开启后单指相对移动鼠标、轻点左键；双指轻点右键、双指滑动滚轮。')
                 .fontSize(11).fontColor($r('app.color.text_secondary')).width('100%')
-              this.SwitchRow('显示触摸光标', '操作时短暂显示鼠标位置与点击反馈', this.settings.virtualMouseConfig.showCursor,
+              this.SwitchRow('显示箭头指针', '触摸板模式用箭头显示鼠标位置，箭头尖即点击点', this.settings.virtualMouseConfig.showCursor,
                 (value: boolean): void => this.updateVirtualMouse(this.settings.virtualMouseConfig.mouseSensitivity, value))
               Text('轻点为左键，双指轻点为右键；轻点后再次按住并移动可拖拽窗口')
                 .fontSize(12).fontColor($r('app.color.text_secondary')).width('100%')
@@ -1963,16 +1985,30 @@ struct SystemSettingsPage {
               Column({ space: 3 }) {
                 Text('重置 Wine 环境').fontSize(14).fontWeight(FontWeight.Medium)
                   .fontColor($r('app.color.text_primary')).width('100%')
-                Text('删除当前 Wine prefix 中的应用数据，仅在环境损坏时使用。')
+                Text('重建 Wine 沙盒并重装运行时。默认保留文档和注册表。')
                   .fontSize(11).fontColor($r('app.color.text_secondary')).width('100%')
               }.layoutWeight(1).alignItems(HorizontalAlign.Start)
             }.width('100%')
+            this.SwitchRow('保留文档和注册表',
+              '开启则还原用户文档与注册表；关闭则全部清空',
+              this.settings.preserveUserDataOnReset,
+              (value: boolean): void => this.setPreserveUserDataOnReset(value),
+              'wine-reset-preserve-user-data')
             Button('重置 Wine prefix').width('100%').height(48).borderRadius(14)
               .backgroundColor('#18D94848')
               .fontColor('#D94848')
               .enabled(!this.engineBusy)
               .id('wine-engine-reset-prefix')
-              .onClick(() => AlertDialog.show({ title: '重置 Wine 环境', message: '这会删除当前 Wine prefix 中的应用数据，且无法撤销。', primaryButton: { value: '取消', action: (): void => {} }, secondaryButton: { value: '重置', fontColor: '#D94848', action: (): void => { this.resetPrefix(); } } }))
+              .onClick(() => AlertDialog.show({
+                title: '重置 Wine 环境',
+                message: this.resetPrefixConfirmMessage(),
+                primaryButton: { value: '取消', action: (): void => {} },
+                secondaryButton: {
+                  value: '重置',
+                  fontColor: '#D94848',
+                  action: (): void => { this.resetPrefix(); }
+                }
+              }))
           }
           .width('100%').padding(14).borderRadius(16)
           .backgroundColor('#0FD94848').border({ width: 1, color: '#28D94848' })

--- a/entry/src/main/ets/service/AppSessionService.ets
+++ b/entry/src/main/ets/service/AppSessionService.ets
@@ -27,6 +27,7 @@ import { WineEngineService } from './WineEngineService';
 import { WineWindowManager } from './WineWindowManager';
 import { InputOverlayWindowCoordinator } from './InputOverlayWindowCoordinator';
 import { AppSettingsStore } from './AppSettingsStore';
+import { AppCatalogService } from './AppCatalogService';
 
 const DOMAIN = 0x0000;
 
@@ -510,7 +511,9 @@ export class AppSessionService {
     this.sessions.clear();
     this.pendingToplevels = [];
     await InputOverlayWindowCoordinator.getInstance().setVisible(false);
-    await WineEngineService.getInstance().resetPrefix();
+    const preserve = AppSettingsStore.getInstance().getGlobalSettings().preserveUserDataOnReset;
+    const home = AppCatalogService.getInstance().getWineHomeDirectory();
+    await WineEngineService.getInstance().resetPrefix(preserve, home);
   }
 
   getSessions(): RuntimeSession[] {

--- a/entry/src/main/ets/service/AppSettingsStore.ets
+++ b/entry/src/main/ets/service/AppSettingsStore.ets
@@ -21,6 +21,7 @@ const APP_SETTINGS_KEY = 'app_settings_v1';
 const LIBRARY_PATH_KEY = 'library_path_v1';
 const CATALOG_CACHE_KEY = 'catalog_cache_v1';
 const RECENT_LAUNCHES_KEY = 'recent_launches_v1';
+const RENDER_MODE_KEY = 'winehua_render_mode_v1';
 // v6 briefly selected single-app on tablets.  Keep the product's desktop
 // workflow as the default and migrate only those tablet installations back.
 const PLATFORM_DEFAULTS_KEY = 'platform_defaults_v7';
@@ -34,6 +35,7 @@ export class AppSettingsStore {
   private recentLaunches: string[] = [];
   private libraryPath: string = '';
   private managedWineWindowsHost: boolean = false;
+  private renderMode: string = 'auto';
 
   static getInstance(): AppSettingsStore {
     if (!AppSettingsStore.instance) AppSettingsStore.instance = new AppSettingsStore();
@@ -49,6 +51,51 @@ export class AppSettingsStore {
     this.loadApps();
     this.libraryPath = this.store.getSync(LIBRARY_PATH_KEY, '') as string;
     this.loadRecentLaunches();
+    this.loadRenderMode();
+  }
+
+  private normalizeRenderMode(value: string): string {
+    if (value === 'dxvk_2_6' || value === 'dxvk_1_10' || value === 'virgl') {
+      return value;
+    }
+    if (value === 'dxvk_modern_2_6') {
+      return 'dxvk_2_6';
+    }
+    if (value === 'dxvk_legacy') {
+      return 'dxvk_1_10';
+    }
+    return 'auto';
+  }
+
+  private loadRenderMode(): void {
+    if (!this.store) {
+      AppStorage.setOrCreate<string>('winehua.render.mode', this.renderMode);
+      return;
+    }
+    this.renderMode = this.normalizeRenderMode(
+      this.store.getSync(RENDER_MODE_KEY, 'auto') as string);
+    AppStorage.setOrCreate<string>('winehua.render.mode', this.renderMode);
+    const preference = this.renderMode === 'dxvk_2_6' ? 'dxvk_modern_2_6' :
+      this.renderMode === 'dxvk_1_10' ? 'dxvk_legacy' : 'auto';
+    AppStorage.setOrCreate<string>('winehua.dxvk.preference', preference);
+    AppStorage.setOrCreate<string>('winehua.dxvk.backend', preference);
+  }
+
+  getRenderMode(): string {
+    return this.renderMode;
+  }
+
+  async setRenderMode(mode: string): Promise<void> {
+    const selected = this.normalizeRenderMode(mode);
+    this.renderMode = selected;
+    AppStorage.setOrCreate<string>('winehua.render.mode', selected);
+    const preference = selected === 'dxvk_2_6' ? 'dxvk_modern_2_6' :
+      selected === 'dxvk_1_10' ? 'dxvk_legacy' : 'auto';
+    AppStorage.setOrCreate<string>('winehua.dxvk.preference', preference);
+    AppStorage.setOrCreate<string>('winehua.dxvk.backend', preference);
+    if (!this.store) return;
+    await this.store.put(RENDER_MODE_KEY, selected);
+    await this.store.flush();
   }
 
   /** Restore the v6 tablet default without overwriting other device preferences. */
@@ -84,7 +131,8 @@ export class AppSettingsStore {
       controlOpacity: current.controlOpacity,
       gamepadDeadzone: current.gamepadDeadzone,
       outputScale: current.outputScale,
-      d3dRendererPreference: current.d3dRendererPreference
+      d3dRendererPreference: current.d3dRendererPreference,
+      preserveUserDataOnReset: current.preserveUserDataOnReset
     };
     await this.store.put(GLOBAL_KEY, JSON.stringify(this.globalSettings));
     await this.store.put(PLATFORM_DEFAULTS_KEY, '1');
@@ -144,7 +192,8 @@ export class AppSettingsStore {
         controlOpacity: stored.controlOpacity ?? defaults.controlOpacity,
         gamepadDeadzone: stored.gamepadDeadzone ?? defaults.gamepadDeadzone,
         outputScale: stored.outputScale ?? defaults.outputScale,
-        d3dRendererPreference: stored.d3dRendererPreference ?? D3DRendererPreference.DXVK
+        d3dRendererPreference: stored.d3dRendererPreference ?? D3DRendererPreference.DXVK,
+        preserveUserDataOnReset: stored.preserveUserDataOnReset ?? defaults.preserveUserDataOnReset
       };
     } catch (_) {
       this.globalSettings = createDefaultGlobalSettings();
@@ -221,7 +270,8 @@ export class AppSettingsStore {
       controlOpacity: current.controlOpacity,
       gamepadDeadzone: current.gamepadDeadzone,
       outputScale: current.outputScale,
-      d3dRendererPreference: current.d3dRendererPreference
+      d3dRendererPreference: current.d3dRendererPreference,
+      preserveUserDataOnReset: current.preserveUserDataOnReset
     });
   }
 
@@ -249,7 +299,8 @@ export class AppSettingsStore {
       controlOpacity: current.controlOpacity,
       gamepadDeadzone: current.gamepadDeadzone,
       outputScale: current.outputScale,
-      d3dRendererPreference: current.d3dRendererPreference
+      d3dRendererPreference: current.d3dRendererPreference,
+      preserveUserDataOnReset: current.preserveUserDataOnReset
     });
   }
 
@@ -277,7 +328,8 @@ export class AppSettingsStore {
       controlOpacity: current.controlOpacity,
       gamepadDeadzone: current.gamepadDeadzone,
       outputScale: current.outputScale,
-      d3dRendererPreference: current.d3dRendererPreference
+      d3dRendererPreference: current.d3dRendererPreference,
+      preserveUserDataOnReset: current.preserveUserDataOnReset
     });
   }
 
@@ -306,7 +358,8 @@ export class AppSettingsStore {
       controlOpacity: current.controlOpacity,
       gamepadDeadzone: current.gamepadDeadzone,
       outputScale: current.outputScale,
-      d3dRendererPreference: current.d3dRendererPreference
+      d3dRendererPreference: current.d3dRendererPreference,
+      preserveUserDataOnReset: current.preserveUserDataOnReset
     });
   }
 
@@ -334,7 +387,8 @@ export class AppSettingsStore {
       controlOpacity: current.controlOpacity,
       gamepadDeadzone: current.gamepadDeadzone,
       outputScale: current.outputScale,
-      d3dRendererPreference: current.d3dRendererPreference
+      d3dRendererPreference: current.d3dRendererPreference,
+      preserveUserDataOnReset: current.preserveUserDataOnReset
     });
   }
 

--- a/entry/src/main/ets/service/IconExtractor.ets
+++ b/entry/src/main/ets/service/IconExtractor.ets
@@ -1,0 +1,449 @@
+import { fileIo as fs } from '@kit.CoreFileKit';
+import { image } from '@kit.ImageKit';
+import { hilog } from './LogService';
+
+const DOMAIN = 0x0000;
+const TAG = 'IconExtractor';
+const CACHE_DIR = '/data/storage/el2/base/cache/icons';
+const RT_ICON = 3;
+const RT_GROUP_ICON = 14;
+
+interface IconCandidate {
+  width: number;
+  height: number;
+  bitCount: number;
+  nId: number;
+}
+
+interface ResDataRef {
+  dataRva: number;
+  size: number;
+}
+
+interface RgbaImage {
+  pixels: ArrayBuffer;
+  width: number;
+  height: number;
+}
+
+/**
+ * exe 图标提取: 自实现 PE .rsrc 解析。
+ * 流程: PE 头 → 资源段 → RT_GROUP_ICON 选候选 → RT_ICON 取数据 →
+ * 内嵌 PNG 直接落盘 / DIB 转 RGBA → PixelMap → PNG 缓存。
+ */
+export class IconExtractor {
+  private static instance: IconExtractor | null = null;
+  private why: string = '';
+
+  static getInstance(): IconExtractor {
+    if (!IconExtractor.instance) {
+      IconExtractor.instance = new IconExtractor();
+    }
+    return IconExtractor.instance;
+  }
+
+  async extract(exePath: string): Promise<string> {
+    const outPath = `${CACHE_DIR}/${this.cacheName(exePath)}`;
+    try {
+      if (fs.accessSync(outPath)) {
+        try {
+          const exeSt = fs.statSync(exePath);
+          const iconSt = fs.statSync(outPath);
+          if (Number(iconSt.mtime) >= Number(exeSt.mtime)) {
+            return outPath;
+          }
+        } catch (_) {
+          return outPath;
+        }
+      }
+      const fd = fs.openSync(exePath, fs.OpenMode.READ_ONLY).fd;
+      try {
+        this.why = '';
+        const png = this.readIconBytes(fd);
+        if (!png) {
+          hilog.warn(DOMAIN, TAG, 'no icon %{public}s: %{public}s', exePath, this.why || 'unknown');
+          return '';
+        }
+        this.ensureCacheDir();
+        if (this.isPng(png)) {
+          const out = fs.openSync(outPath, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
+          fs.writeSync(out.fd, png);
+          fs.closeSync(out);
+          return outPath;
+        }
+        const rgba = this.dibToRgba(png);
+        if (!rgba) {
+          hilog.warn(DOMAIN, TAG, 'no icon %{public}s: %{public}s', exePath, this.why || 'dib');
+          return '';
+        }
+        return await this.writePng(rgba.pixels, rgba.width, rgba.height, outPath);
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch (e) {
+      hilog.warn(DOMAIN, TAG, 'extract fail %{public}s: %{public}s', exePath, JSON.stringify(e));
+      return '';
+    }
+  }
+
+  private cacheName(exePath: string): string {
+    let h = 5381;
+    for (let i = 0; i < exePath.length; i++) {
+      h = (((h << 5) + h) + exePath.charCodeAt(i)) | 0;
+    }
+    const base = exePath.substring(exePath.lastIndexOf('/') + 1)
+      .replace(/[^A-Za-z0-9._-]/g, '_')
+      .substring(0, 40);
+    return `${(h >>> 0).toString(16)}_${base}.png`;
+  }
+
+  private ensureCacheDir(): void {
+    if (!fs.accessSync(CACHE_DIR)) {
+      fs.mkdirSync(CACHE_DIR, true);
+    }
+  }
+
+  private readAt(fd: number, offset: number, length: number): ArrayBuffer | null {
+    if (length <= 0) {
+      return null;
+    }
+    const buf = new ArrayBuffer(length);
+    const n = fs.readSync(fd, buf, { offset: offset, length: length });
+    return n >= length ? buf : null;
+  }
+
+  private readIconBytes(fd: number): ArrayBuffer | null {
+    const dos = this.readAt(fd, 0, 64);
+    if (!dos) {
+      this.why = 'read-dos';
+      return null;
+    }
+    const dv = new DataView(dos);
+    if (dv.getUint16(0, true) !== 0x5A4D) {
+      this.why = 'not-mz';
+      return null;
+    }
+    const peOff = dv.getUint32(0x3C, true);
+    const pe = this.readAt(fd, peOff, 24);
+    if (!pe) {
+      this.why = 'read-pe';
+      return null;
+    }
+    const pv = new DataView(pe);
+    if (pv.getUint32(0, true) !== 0x00004550) {
+      this.why = 'not-pe';
+      return null;
+    }
+    const numSections = pv.getUint16(6, true);
+    const optSize = pv.getUint16(20, true);
+    const opt = this.readAt(fd, peOff + 24, optSize);
+    if (!opt || optSize < 2) {
+      this.why = 'read-opt';
+      return null;
+    }
+    const ov = new DataView(opt);
+    const magic = ov.getUint16(0, true);
+    const dirBase = magic === 0x20B ? 112 : (magic === 0x10B ? 96 : -1);
+    if (dirBase < 0 || dirBase + 24 > optSize) {
+      this.why = 'bad-magic';
+      return null;
+    }
+    const resRva = ov.getUint32(dirBase + 16, true);
+    if (resRva === 0) {
+      this.why = 'no-rsrc';
+      return null;
+    }
+    const secOff = peOff + 24 + optSize;
+    const secs = this.readAt(fd, secOff, numSections * 40);
+    if (!secs) {
+      this.why = 'read-sections';
+      return null;
+    }
+    const sv = new DataView(secs);
+    const rvaToOff = (rva: number, size: number): number => {
+      for (let i = 0; i < numSections; i++) {
+        const b = i * 40;
+        const vsize = sv.getUint32(b + 8, true);
+        const vaddr = sv.getUint32(b + 12, true);
+        const rawSize = sv.getUint32(b + 16, true);
+        const rawPtr = sv.getUint32(b + 20, true);
+        if (rva >= vaddr && rva + size <= vaddr + Math.max(vsize, rawSize)) {
+          return rawPtr + (rva - vaddr);
+        }
+      }
+      return -1;
+    };
+    return this.readGroupIcon(fd, rvaToOff, resRva);
+  }
+
+  private findTypeDir(fd: number, resOff: number, typeId: number): number {
+    const hdr = this.readAt(fd, resOff + 12, 4);
+    if (!hdr) {
+      return -1;
+    }
+    const hv = new DataView(hdr);
+    const total = hv.getUint16(0, true) + hv.getUint16(2, true);
+    const entries = this.readAt(fd, resOff + 16, total * 8);
+    if (!entries) {
+      return -1;
+    }
+    const ev = new DataView(entries);
+    for (let i = 0; i < total; i++) {
+      const id = ev.getUint32(i * 8, true);
+      const off = ev.getUint32(i * 8 + 4, true);
+      if (!(id & 0x80000000) && (id & 0xFFFF) === typeId && (off & 0x80000000)) {
+        return off & 0x7FFFFFFF;
+      }
+    }
+    return -1;
+  }
+
+  private firstDataRef(fd: number, resOff: number, dirOff: number): ResDataRef | null {
+    return this.dataRefByIndex(fd, resOff, dirOff, -1);
+  }
+
+  private dataRefByIndex(fd: number, resOff: number, dirOff: number, wantId: number): ResDataRef | null {
+    const hdr = this.readAt(fd, resOff + dirOff + 12, 4);
+    if (!hdr) {
+      return null;
+    }
+    const hv = new DataView(hdr);
+    const total = hv.getUint16(0, true) + hv.getUint16(2, true);
+    const entries = this.readAt(fd, resOff + dirOff + 16, total * 8);
+    if (!entries) {
+      return null;
+    }
+    const ev = new DataView(entries);
+    for (let i = 0; i < total; i++) {
+      const id = ev.getUint32(i * 8, true);
+      const off = ev.getUint32(i * 8 + 4, true);
+      if (id & 0x80000000 || !(off & 0x80000000)) {
+        continue;
+      }
+      if (wantId >= 0 && (id & 0xFFFF) !== wantId) {
+        continue;
+      }
+      const langDir = off & 0x7FFFFFFF;
+      const lhdr = this.readAt(fd, resOff + langDir + 12, 4);
+      if (!lhdr) {
+        return null;
+      }
+      const lv = new DataView(lhdr);
+      const ltotal = lv.getUint16(0, true) + lv.getUint16(2, true);
+      if (ltotal <= 0) {
+        return null;
+      }
+      const dentry = this.readAt(fd, resOff + langDir + 16, 8);
+      if (!dentry) {
+        return null;
+      }
+      const dvv = new DataView(dentry);
+      const dataOff = dvv.getUint32(4, true);
+      if (dataOff & 0x80000000) {
+        return null;
+      }
+      const dataEntry = this.readAt(fd, resOff + dataOff, 8);
+      if (!dataEntry) {
+        return null;
+      }
+      const dev = new DataView(dataEntry);
+      return { dataRva: dev.getUint32(0, true), size: dev.getUint32(4, true) };
+    }
+    return null;
+  }
+
+  private readGroupIcon(fd: number, rvaToOff: (rva: number, size: number) => number,
+    resRva: number): ArrayBuffer | null {
+    const resOff = rvaToOff(resRva, 16);
+    if (resOff < 0) {
+      this.why = 'rsrc-unmapped';
+      return null;
+    }
+    const groupDirOff = this.findTypeDir(fd, resOff, RT_GROUP_ICON);
+    if (groupDirOff < 0) {
+      this.why = 'no-group-icon';
+      return null;
+    }
+    const groupRef = this.firstDataRef(fd, resOff, groupDirOff);
+    if (!groupRef) {
+      this.why = 'group-ref';
+      return null;
+    }
+    const groupFileOff = rvaToOff(groupRef.dataRva, groupRef.size);
+    if (groupFileOff < 0) {
+      this.why = 'group-unmapped';
+      return null;
+    }
+    const grp = this.readAt(fd, groupFileOff, groupRef.size);
+    if (!grp || groupRef.size < 6) {
+      this.why = 'group-read';
+      return null;
+    }
+    const gv = new DataView(grp);
+    const count = gv.getUint16(4, true);
+    const cands: IconCandidate[] = [];
+    for (let i = 0; i < count; i++) {
+      const b = 6 + i * 14;
+      if (b + 14 > groupRef.size) {
+        break;
+      }
+      const w = gv.getUint8(b) || 256;
+      const h = gv.getUint8(b + 1) || 256;
+      cands.push({
+        width: w,
+        height: h,
+        bitCount: gv.getUint16(b + 6, true),
+        nId: gv.getUint16(b + 12, true)
+      });
+    }
+    cands.sort((a: IconCandidate, b: IconCandidate) =>
+      (b.width * b.height - a.width * a.height) || (b.bitCount - a.bitCount));
+    const iconDirOff = this.findTypeDir(fd, resOff, RT_ICON);
+    if (iconDirOff < 0) {
+      this.why = 'no-icon-dir';
+      return null;
+    }
+    for (const cand of cands) {
+      const ref = this.dataRefByIndex(fd, resOff, iconDirOff, cand.nId);
+      if (!ref || ref.size <= 0 || ref.size > 4 * 1024 * 1024) {
+        this.why = `cand-ref-nid${cand.nId}`;
+        continue;
+      }
+      const off = rvaToOff(ref.dataRva, ref.size);
+      if (off < 0) {
+        this.why = `cand-unmapped-nid${cand.nId}`;
+        continue;
+      }
+      const data = this.readAt(fd, off, ref.size);
+      if (data) {
+        return data;
+      }
+      this.why = `cand-read-nid${cand.nId}-sz${ref.size}`;
+    }
+    return null;
+  }
+
+  private isPng(data: ArrayBuffer): boolean {
+    if (data.byteLength < 8) {
+      return false;
+    }
+    const v = new Uint8Array(data);
+    return v[0] === 0x89 && v[1] === 0x50 && v[2] === 0x4E && v[3] === 0x47;
+  }
+
+  private dibToRgba(data: ArrayBuffer): RgbaImage | null {
+    if (data.byteLength < 40) {
+      return null;
+    }
+    const dv = new DataView(data);
+    const hdrSize = dv.getUint32(0, true);
+    const width = dv.getInt32(4, true);
+    const rawHeight = dv.getInt32(8, true);
+    const bpp = dv.getUint16(14, true);
+    const compression = dv.getUint32(16, true);
+    const clrUsed = dv.getUint32(32, true);
+    if (width <= 0 || rawHeight <= 0 || rawHeight % 2 !== 0 || compression !== 0) {
+      return null;
+    }
+    if (bpp !== 32 && bpp !== 24 && bpp !== 8 && bpp !== 4) {
+      return null;
+    }
+    const height = rawHeight / 2;
+    let palette: Uint8Array | null = null;
+    let paletteCount = 0;
+    if (bpp <= 8) {
+      paletteCount = clrUsed > 0 ? clrUsed : (1 << bpp);
+      if (hdrSize + paletteCount * 4 > data.byteLength) {
+        return null;
+      }
+      palette = new Uint8Array(data, hdrSize, paletteCount * 4);
+    }
+    const xorOff = hdrSize + paletteCount * 4;
+    const xorRow = Math.floor((width * bpp + 31) / 32) * 4;
+    const andRow = Math.floor((width + 31) / 32) * 4;
+    if (xorOff + xorRow * height > data.byteLength) {
+      return null;
+    }
+    const hasAnd = xorOff + xorRow * height + andRow * height <= data.byteLength;
+    const andOff = xorOff + xorRow * height;
+    const src = new Uint8Array(data);
+    const out = new Uint8Array(width * height * 4);
+    let opaqueAlphaHint = true;
+    for (let y = 0; y < height; y++) {
+      const srcRow = xorOff + (height - 1 - y) * xorRow;
+      const andRowOff = andOff + (height - 1 - y) * andRow;
+      for (let x = 0; x < width; x++) {
+        const o = (y * width + x) * 4;
+        let r = 0;
+        let g = 0;
+        let b = 0;
+        let a = 255;
+        if (bpp === 32) {
+          const p = srcRow + x * 4;
+          b = src[p];
+          g = src[p + 1];
+          r = src[p + 2];
+          a = src[p + 3];
+          if (a !== 0) {
+            opaqueAlphaHint = false;
+          }
+        } else if (bpp === 24) {
+          const p = srcRow + x * 3;
+          b = src[p];
+          g = src[p + 1];
+          r = src[p + 2];
+        } else if (bpp === 8) {
+          const idx = src[srcRow + x];
+          if (palette && idx < paletteCount) {
+            b = palette[idx * 4];
+            g = palette[idx * 4 + 1];
+            r = palette[idx * 4 + 2];
+          }
+        } else {
+          const byte = src[srcRow + Math.floor(x / 2)];
+          const idx = (x % 2 === 0) ? (byte >> 4) : (byte & 0x0F);
+          if (palette && idx < paletteCount) {
+            b = palette[idx * 4];
+            g = palette[idx * 4 + 1];
+            r = palette[idx * 4 + 2];
+          }
+        }
+        if (hasAnd) {
+          const andByte = src[andRowOff + Math.floor(x / 8)];
+          if ((andByte >> (7 - (x % 8))) & 1) {
+            a = 0;
+          }
+        }
+        out[o] = r;
+        out[o + 1] = g;
+        out[o + 2] = b;
+        out[o + 3] = a;
+      }
+    }
+    if (bpp === 32 && opaqueAlphaHint && !hasAnd) {
+      for (let i = 3; i < out.length; i += 4) {
+        out[i] = 255;
+      }
+    }
+    return { pixels: out.buffer as ArrayBuffer, width: width, height: height };
+  }
+
+  private async writePng(rgba: ArrayBuffer, width: number, height: number, outPath: string): Promise<string> {
+    const opts: image.InitializationOptions = {
+      size: { width: width, height: height },
+      pixelFormat: image.PixelMapFormat.RGBA_8888,
+      editable: false
+    };
+    const pixelMap = await image.createPixelMap(rgba, opts);
+    this.ensureCacheDir();
+    const out = fs.openSync(outPath, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
+    try {
+      const packer = image.createImagePacker();
+      const packOpts: image.PackingOption = { format: 'image/png', quality: 100 };
+      await packer.packToFile(pixelMap, out.fd, packOpts);
+    } finally {
+      fs.closeSync(out);
+    }
+    return outPath;
+  }
+}

--- a/entry/src/main/ets/service/InputOverlayWindowCoordinator.ets
+++ b/entry/src/main/ets/service/InputOverlayWindowCoordinator.ets
@@ -29,6 +29,13 @@ export interface InputOverlaySnapshot {
 
 export type InputOverlayListener = (snapshot: InputOverlaySnapshot) => void;
 
+interface OverlayWindowRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
 const OVERLAY_DOMAIN = 0x0000;
 const OVERLAY_TAG = 'InputOverlay';
 
@@ -418,6 +425,18 @@ export class InputOverlayWindowCoordinator {
     }
     this.publish();
     setTimeout(() => this.runNextStressFrame(), 16);
+  }
+
+  /** Overlay window bounds in physical pixels. Size is the virtual-cursor clamp. */
+  getOverlayWindowRect(): OverlayWindowRect {
+    if (!this.overlayWindow) {
+      return { left: 0, top: 0, width: 0, height: 0 };
+    }
+    try {
+      return this.overlayWindow.getWindowProperties().windowRect;
+    } catch (_) {
+      return { left: 0, top: 0, width: 0, height: 0 };
+    }
   }
 
   async detach(reason: string): Promise<void> {

--- a/entry/src/main/ets/service/InputOverlayWindowCoordinator.ets
+++ b/entry/src/main/ets/service/InputOverlayWindowCoordinator.ets
@@ -38,6 +38,7 @@ interface OverlayWindowRect {
 
 const OVERLAY_DOMAIN = 0x0000;
 const OVERLAY_TAG = 'InputOverlay';
+const OVERLAY_HIDDEN_ORIGIN: number = -10000;
 
 /** 透明 ArkTS 子窗口的生命周期所有者，不受 Wine XComponent 帧提交影响。 */
 export class InputOverlayWindowCoordinator {
@@ -50,6 +51,8 @@ export class InputOverlayWindowCoordinator {
   private stressRemaining: number = 0;
   private attaching: boolean = false;
   private boundsSyncGeneration: number = 0;
+  private visibilityGeneration: number = 0;
+  private visibilityOp: Promise<void> = Promise.resolve();
   private snapshot: InputOverlaySnapshot = {
     session: { sessionId: '', displayMode: DisplayMode.DESKTOP, toplevelId: 0, active: false },
     profileId: 'default', enabled: true, visible: false, controlsVisible: true, opacity: 72,
@@ -154,7 +157,7 @@ export class InputOverlayWindowCoordinator {
       try {
         overlay = await stage.createSubWindowWithOptions('wine_input_overlay', {
           title: '', decorEnabled: false, isModal: false, zLevel: 9000,
-          maximizeSupported: true,
+          maximizeSupported: false,
           windowRect: {
             left: Math.round(initLeft), top: Math.round(initialRect.top),
             width: Math.max(1, Math.round(initWidth)),
@@ -183,6 +186,7 @@ export class InputOverlayWindowCoordinator {
       }
       this.overlayWindow = overlay;
       try { await overlay.setWindowFocusable(false); } catch (_) {}
+      try { await overlay.setWindowDecorVisible(false); } catch (_) {}
       await overlay.loadContent('pages/InputOverlay');
       hilog.info(OVERLAY_DOMAIN, OVERLAY_TAG, 'overlay content loaded');
       await this.syncBounds();
@@ -266,24 +270,72 @@ export class InputOverlayWindowCoordinator {
   }
 
   async setVisible(visible: boolean): Promise<void> {
+    const generation = ++this.visibilityGeneration;
     const resolvedVisible = visible && this.snapshot.enabled;
     this.snapshot.visible = resolvedVisible;
-    if (this.overlayWindow) {
-      // A subwindow is automatically hidden while its parent Ability is in the
-      // background. Merely restoring touchability does not make it visible
-      // again on API 23, so editor return must explicitly show the retained
-      // single overlay window before enabling input.
-      if (resolvedVisible) {
-        try { await this.overlayWindow.showWindow(); } catch (error) {
-          this.snapshot.lastError = 'showWindow: ' + JSON.stringify(error);
-        }
+    if (!resolvedVisible) {
+      InputDispatcher.getInstance().releaseAll('overlay-hidden');
+    }
+    const pending: Promise<void> = this.visibilityOp.then((): Promise<void> => {
+      return this.applyVisibility(generation, resolvedVisible);
+    }).catch((): Promise<void> => {
+      return this.applyVisibility(generation, resolvedVisible);
+    });
+    this.visibilityOp = pending.then((): void => {}).catch((): void => {});
+    await pending;
+    if (generation === this.visibilityGeneration) {
+      this.publish();
+    }
+  }
+
+  /**
+   * Subwindows have no hide(). Keep the retained overlay off-screen and
+   * non-touchable instead of collapsing it to 1x1 at (0,0), which can surface
+   * as a titled speck and race with the next syncBounds.
+   */
+  private async applyVisibility(generation: number, resolvedVisible: boolean): Promise<void> {
+    if (generation !== this.visibilityGeneration) {
+      return;
+    }
+    const overlay = this.overlayWindow;
+    if (!overlay) {
+      return;
+    }
+    if (resolvedVisible) {
+      try {
+        await overlay.showWindow();
+      } catch (error) {
+        this.snapshot.lastError = 'showWindow: ' + JSON.stringify(error);
       }
-      try { await this.overlayWindow.setWindowTouchable(resolvedVisible); } catch (error) {
+      if (generation !== this.visibilityGeneration) {
+        return;
+      }
+      await this.syncBounds();
+      if (generation !== this.visibilityGeneration) {
+        return;
+      }
+      try {
+        await overlay.setWindowTouchable(true);
+      } catch (error) {
         this.snapshot.lastError = 'setWindowTouchable: ' + JSON.stringify(error);
       }
+      await this.raise();
+      return;
     }
-    if (!resolvedVisible) InputDispatcher.getInstance().releaseAll('overlay-hidden');
-    this.publish();
+    try {
+      await overlay.setWindowTouchable(false);
+    } catch (error) {
+      this.snapshot.lastError = 'setWindowTouchable: ' + JSON.stringify(error);
+    }
+    if (generation !== this.visibilityGeneration) {
+      return;
+    }
+    this.boundsSyncGeneration++;
+    try {
+      await overlay.moveWindowToGlobal(OVERLAY_HIDDEN_ORIGIN, OVERLAY_HIDDEN_ORIGIN);
+    } catch (error) {
+      this.snapshot.lastError = 'collapse overlay: ' + JSON.stringify(error);
+    }
   }
 
   async setEnabled(enabled: boolean): Promise<void> {
@@ -317,7 +369,12 @@ export class InputOverlayWindowCoordinator {
   }
 
   async syncBounds(): Promise<void> {
-    if (!this.overlayWindow || !this.parentWindow) return;
+    if (!this.overlayWindow || !this.parentWindow) {
+      return;
+    }
+    if (!this.snapshot.visible && !this.attaching) {
+      return;
+    }
     try {
       const rect = this.parentWindow.getWindowProperties().windowRect;
       // 切边模式: 输入覆盖层与桌面 XComponent 同步左右内缩, 使覆盖层
@@ -440,6 +497,7 @@ export class InputOverlayWindowCoordinator {
   }
 
   async detach(reason: string): Promise<void> {
+    this.visibilityGeneration++;
     this.boundsSyncGeneration++;
     InputDispatcher.getInstance().releaseAll(reason);
     const overlay = this.overlayWindow;

--- a/entry/src/main/ets/service/WineEngineService.ets
+++ b/entry/src/main/ets/service/WineEngineService.ets
@@ -11,7 +11,9 @@ import {
   NativeProcessInfo,
   ScreenOrientationSetting,
   WinePresentationMode,
-  canTransitionEngineState
+  canTransitionEngineState,
+  LaunchKind,
+  resolveWinePresentationMode
 } from '../model/AppModels';
 import { AppSettingsStore } from './AppSettingsStore';
 import { syncManagedSmoke } from './SmokeRunner';
@@ -35,6 +37,11 @@ const PREFIX_SYSTEM_REG = FILES_BASE + '/.wine/system.reg';
 // ArkTS 不再用固定阶段死线: native 协调者会发 phase:/fail:/wine-ready 事件,
 // 等待只由事件结束。下面的安全网仅在"长时间完全无事件"时兜底, 正常不会触发。
 const ENGINE_NO_EVENT_SAFETY_MS = 30 * 60 * 1000;
+const PREFIX_DIR = FILES_BASE + '/.wine';
+const RESET_KEEP_DIR = '/data/storage/el2/base/cache/wine-reset-keep';
+const PREFIX_USER_KEEP_FOLDERS: string[] = [
+  'Documents', 'Desktop', 'Pictures', 'Music', 'Videos', 'Saved Games'
+];
 const HOST_SHADOW_DXVK = 'shadow-precise-dirty-ring-inline-upload-coverage-sort';
 const HOST_SHADOW_VKD3D = 'shadow-precise';
 
@@ -131,6 +138,136 @@ function pathMatchesRequirement(item: RuntimePathRequirement): boolean {
 function isCommandScript(executable: string): boolean {
   const lower = executable.trim().toLowerCase();
   return lower.endsWith('.bat') || lower.endsWith('.cmd');
+}
+
+function ensureDirectory(path: string): void {
+  if (!pathExists(path)) {
+    fs.mkdirSync(path, true);
+  }
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return fs.statSync(path).isDirectory();
+  } catch (_) {
+    return false;
+  }
+}
+
+function removeRecursive(path: string): void {
+  if (!pathExists(path)) {
+    return;
+  }
+  try {
+    const stat = fs.lstatSync(path);
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      fs.unlinkSync(path);
+      return;
+    }
+  } catch (_) {
+    return;
+  }
+  try {
+    const names = fs.listFileSync(path);
+    for (let i = 0; i < names.length; i++) {
+      removeRecursive(`${path}/${names[i]}`);
+    }
+  } catch (_) {}
+  try {
+    fs.rmdirSync(path);
+  } catch (_) {}
+}
+
+function copyRecursiveOrThrow(source: string, target: string): void {
+  const stat = fs.statSync(source);
+  if (!stat.isDirectory()) {
+    const slash = target.lastIndexOf('/');
+    if (slash > 0) {
+      ensureDirectory(target.substring(0, slash));
+    }
+    fs.copyFileSync(source, target);
+    return;
+  }
+  ensureDirectory(target);
+  const names = fs.listFileSync(source);
+  for (let i = 0; i < names.length; i++) {
+    copyRecursiveOrThrow(`${source}/${names[i]}`, `${target}/${names[i]}`);
+  }
+}
+
+function backupPrefixUserData(keepDir: string): void {
+  removeRecursive(keepDir);
+  ensureDirectory(keepDir);
+  if (!pathExists(PREFIX_DIR)) {
+    return;
+  }
+  const regs: string[] = ['user.reg', 'system.reg', 'userdef.reg'];
+  for (let i = 0; i < regs.length; i++) {
+    const src = `${PREFIX_DIR}/${regs[i]}`;
+    if (pathExists(src)) {
+      copyRecursiveOrThrow(src, `${keepDir}/${regs[i]}`);
+    }
+  }
+  const users = `${PREFIX_DIR}/drive_c/users`;
+  if (!pathExists(users) || !isDirectory(users)) {
+    return;
+  }
+  let names: string[] = [];
+  try {
+    names = fs.listFileSync(users);
+  } catch (_) {
+    return;
+  }
+  for (let u = 0; u < names.length; u++) {
+    const userDir = `${users}/${names[u]}`;
+    if (!isDirectory(userDir)) {
+      continue;
+    }
+    for (let f = 0; f < PREFIX_USER_KEEP_FOLDERS.length; f++) {
+      const folder = PREFIX_USER_KEEP_FOLDERS[f];
+      const src = `${userDir}/${folder}`;
+      if (pathExists(src)) {
+        copyRecursiveOrThrow(src, `${keepDir}/users/${names[u]}/${folder}`);
+      }
+    }
+  }
+}
+
+function restorePrefixUserData(keepDir: string): void {
+  if (!pathExists(keepDir)) {
+    return;
+  }
+  ensureDirectory(PREFIX_DIR);
+  const regs: string[] = ['user.reg', 'system.reg', 'userdef.reg'];
+  for (let i = 0; i < regs.length; i++) {
+    const src = `${keepDir}/${regs[i]}`;
+    if (pathExists(src)) {
+      copyRecursiveOrThrow(src, `${PREFIX_DIR}/${regs[i]}`);
+    }
+  }
+  const usersKeep = `${keepDir}/users`;
+  if (!pathExists(usersKeep) || !isDirectory(usersKeep)) {
+    return;
+  }
+  let names: string[] = [];
+  try {
+    names = fs.listFileSync(usersKeep);
+  } catch (_) {
+    return;
+  }
+  for (let u = 0; u < names.length; u++) {
+    const userDir = `${usersKeep}/${names[u]}`;
+    if (!isDirectory(userDir)) {
+      continue;
+    }
+    for (let f = 0; f < PREFIX_USER_KEEP_FOLDERS.length; f++) {
+      const folder = PREFIX_USER_KEEP_FOLDERS[f];
+      const src = `${userDir}/${folder}`;
+      if (pathExists(src)) {
+        copyRecursiveOrThrow(src, `${PREFIX_DIR}/drive_c/users/${names[u]}/${folder}`);
+      }
+    }
+  }
 }
 
 export class WineEngineService {
@@ -358,14 +495,15 @@ export class WineEngineService {
   }
 
   private selectedD3DBackend(): string {
-    const mode = AppStorage.get<string>('winehua.render.mode') ?? 'auto';
+    const stored = AppSettingsStore.getInstance().getRenderMode();
+    const mode = stored.length > 0 ? stored :
+      (AppStorage.get<string>('winehua.render.mode') ?? 'auto');
     let backend = 'dxvk_legacy';
     if (mode === 'virgl') {
       backend = 'wined3d';
     } else if (mode === 'dxvk_1_10') {
       backend = 'dxvk_legacy';
     } else if (this.gpuSupportsDxvk26()) {
-      // auto / dxvk_2_6: Maleoon/Mali-G 920+ → DXVK 2.6 + VKD3D
       backend = 'dxvk_modern_2_6';
     }
     AppStorage.setOrCreate<string>('winehua.render.resolved', backend);
@@ -475,10 +613,50 @@ export class WineEngineService {
     await this.stopAll();
   }
 
-  async resetPrefix(): Promise<void> {
+  async resetPrefix(preserveUserData?: boolean, homeDirectory?: string): Promise<void> {
+    const preserve = preserveUserData ??
+      AppSettingsStore.getInstance().getGlobalSettings().preserveUserDataOnReset;
+    const home = homeDirectory ?? '';
     await this.stopAll();
+    if (preserve) {
+      try {
+        backupPrefixUserData(RESET_KEEP_DIR);
+      } catch (error) {
+        hilog.error(DOMAIN, TAG, 'prefix user-data backup failed: %{public}s', JSON.stringify(error));
+        this.setState(EngineState.ERROR, '备份文档或注册表失败，已中止重置');
+        throw error;
+      }
+    }
     testNapi.resetWinePrefix();
+    await this.forceRefreshRuntime();
+    if (preserve) {
+      try {
+        restorePrefixUserData(RESET_KEEP_DIR);
+        removeRecursive(RESET_KEEP_DIR);
+      } catch (error) {
+        hilog.error(DOMAIN, TAG, 'prefix user-data restore failed: %{public}s', JSON.stringify(error));
+        this.setState(EngineState.ERROR, '还原文档或注册表失败，备份仍在 cache/wine-reset-keep');
+        throw error;
+      }
+    } else {
+      removeRecursive(RESET_KEEP_DIR);
+    }
+    if (home.length > 0) {
+      const settings = AppSettingsStore.getInstance().getGlobalSettings();
+      const presentation = resolveWinePresentationMode(
+        LaunchKind.WINE_EXE, settings.defaultDisplayMode,
+        AppSettingsStore.getInstance().usesManagedWineWindows());
+      await this.ensureReady(settings.defaultDisplayMode, presentation, home);
+      return;
+    }
     this.setState(EngineState.STOPPED, 'Wine 环境已重置');
+  }
+
+  private async forceRefreshRuntime(): Promise<void> {
+    try { fs.unlinkSync(RUNTIME_VERSION_MARKER); } catch (_) {}
+    try { fs.unlinkSync(PREFIX_RUNTIME_VERSION_MARKER); } catch (_) {}
+    const bundled = this.getBundledRuntimeVersion();
+    await this.ensureRuntimeInstalled(bundled);
   }
 
   private waitForReady(): Promise<boolean> {

--- a/entry/src/main/ets/service/WineEngineService.ets
+++ b/entry/src/main/ets/service/WineEngineService.ets
@@ -624,7 +624,7 @@ export class WineEngineService {
       } catch (error) {
         hilog.error(DOMAIN, TAG, 'prefix user-data backup failed: %{public}s', JSON.stringify(error));
         this.setState(EngineState.ERROR, '备份文档或注册表失败，已中止重置');
-        throw error;
+        throw new Error('备份文档或注册表失败: ' + JSON.stringify(error));
       }
     }
     testNapi.resetWinePrefix();
@@ -636,7 +636,7 @@ export class WineEngineService {
       } catch (error) {
         hilog.error(DOMAIN, TAG, 'prefix user-data restore failed: %{public}s', JSON.stringify(error));
         this.setState(EngineState.ERROR, '还原文档或注册表失败，备份仍在 cache/wine-reset-keep');
-        throw error;
+        throw new Error('还原文档或注册表失败: ' + JSON.stringify(error));
       }
     } else {
       removeRecursive(RESET_KEEP_DIR);

--- a/entry/src/main/ets/service/WineWindowManager.ets
+++ b/entry/src/main/ets/service/WineWindowManager.ets
@@ -47,6 +47,8 @@ export class WineWindowManager {
   // 桌面启动器/悬浮窗可见性 (浮窗模式): Index 悬浮窗态=true → DesktopLayer
   // 跳过 root resize (桌面分辨率保持全屏, 缩略显示靠 letterbox); 全屏态=false
   desktopLauncherVisible: boolean = true;
+  /** Index 浮窗放大/缩小动画进行中: 跳过 Wine 桌面 resize，避免 explorer root switch。 */
+  floatingLayoutAnimating: boolean = false;
   private desktopAbilityRunning: boolean = false;
   private desktopAbilityForeground: boolean = false;
   private desktopAbilityRootId: number = 0;
@@ -214,7 +216,7 @@ export class WineWindowManager {
     }
   }
 
-  syncOutputSize(widthPx: number, heightPx: number): void {
+  syncOutputSize(widthPx: number, heightPx: number, forceToplevelResize: boolean = false): void {
     if (widthPx <= 0 || heightPx <= 0) return;
     try {
       const currentDisplay = display.getDefaultDisplaySync();
@@ -232,9 +234,11 @@ export class WineWindowManager {
       // PC 虚拟桌面浮窗: 桌面分辨率固定 (init setOutputSize = 屏幕/scale), 窗口
       // 只是显示口 (letterbox 等比完整呈现) — 跳过 notifyToplevelResize, 否则
       // 浮窗尺寸/标题栏偏差触发 Wine 桌面重排, 底部任务栏/开始菜单被裁。
-      // 对齐 master VirtualDesktop desktopLauncherVisible 门控语义。
+      // Index 浮窗: 缩略/缩放动画中 letterbox, 只在 prepareOutputForOrientation
+      // (force) 时改 Wine 桌面尺寸, 避免 explorer 再提交一个 desktop-shell。
       if (this.presentationMode === WinePresentationMode.DESKTOP && this.desktopRootId > 0 &&
-        !(AppSettingsStore.getInstance().usesManagedWineWindows() && this.isDesktopMode)) {
+        !(AppSettingsStore.getInstance().usesManagedWineWindows() && this.isDesktopMode) &&
+        this.shouldNotifyDesktopToplevelResize(forceToplevelResize)) {
         testNapi.notifyToplevelResize(this.desktopRootId, outW, outH);
       }
       hilog.info(DOMAIN, TAG,
@@ -272,7 +276,7 @@ export class WineWindowManager {
         height = swapped;
       }
       const safe = this.desktopDisplaySafeSize(width, height);
-      this.syncOutputSize(safe.width, safe.height);
+      this.syncOutputSize(safe.width, safe.height, true);
       hilog.info(DOMAIN, TAG, '[MW] prepared output orientation=%{public}s size=%{public}dx%{public}d',
         setting, width, height);
     } catch (error) {
@@ -773,6 +777,32 @@ export class WineWindowManager {
     }
   }
 
+  /**
+   * PC 退出沉浸全屏。手机/平板只需藏/恢复系统栏；PC 必须先 EXIT_IMMERSIVE
+   * 才能让标题栏和关闭/最小化回来，否则 recover() 会停在无标题的沉浸态。
+   */
+  async exitImmersiveFullscreen(win: window.Window, recoverWindowed: boolean = false,
+    logId: number = 0): Promise<void> {
+    const label = logId > 0 ? '#' + logId.toString() : 'desktop';
+    try {
+      hilog.info(DOMAIN, TAG, '[MW] exit immersive %{public}s → EXIT_IMMERSIVE', label);
+      await win.maximize(window.MaximizePresentation.EXIT_IMMERSIVE);
+      hilog.info(DOMAIN, TAG, '[MW] exit immersive %{public}s OK', label);
+    } catch (err) {
+      hilog.warn(DOMAIN, TAG, '[MW] exit immersive %{public}s failed: %{public}s',
+        label, JSON.stringify(err));
+    }
+    if (recoverWindowed) {
+      try {
+        await win.recover();
+        hilog.info(DOMAIN, TAG, '[MW] recover after exit immersive %{public}s OK', label);
+      } catch (err) {
+        hilog.warn(DOMAIN, TAG, '[MW] recover after exit immersive %{public}s failed: %{public}s',
+          label, JSON.stringify(err));
+      }
+    }
+  }
+
   // -- apply 单个事件到 window.Window --
   private applyEvent(toplevelId: number, event: string, data: string): void {
     const win = this.windows.get(toplevelId);
@@ -891,16 +921,10 @@ export class WineWindowManager {
       case 'unfullscreen':
         // 退出沉浸式全屏, 恢复普通窗口; 尺寸由 C++ 侧 configure(preFs)
         // → resize 事件恢复 (tl_unset_fullscreen 用 preFs 尺寸)
-        try {
-          hilog.info(DOMAIN, TAG, '[MW] unfullscreen #%{public}d → win.maximize(EXIT_IMMERSIVE)', toplevelId);
-          win.maximize(window.MaximizePresentation.EXIT_IMMERSIVE).then(() => {
-            hilog.info(DOMAIN, TAG, '[MW] unfullscreen OK #%{public}d', toplevelId);
-          }).catch((err: Error) => {
-            hilog.warn(DOMAIN, TAG, '[MW] unfullscreen #%{public}d failed: %{public}s', toplevelId, JSON.stringify(err));
-          });
-        } catch (err) {
-          hilog.warn(DOMAIN, TAG, '[MW] unfullscreen #%{public}d exception: %{public}s', toplevelId, JSON.stringify(err));
-        }
+        this.exitImmersiveFullscreen(win, false, toplevelId).catch((err: Error) => {
+          hilog.warn(DOMAIN, TAG, '[MW] unfullscreen #%{public}d failed: %{public}s',
+            toplevelId, JSON.stringify(err));
+        });
         break;
       case 'argb':
         /*
@@ -1134,7 +1158,7 @@ export class WineWindowManager {
     }
   }
 
-  /** PC 虚拟桌面 hover 菜单: 退出沉浸全屏 (recover 回普通窗口)。 */
+  /** PC 虚拟桌面: 先 EXIT_IMMERSIVE 再 recover，标题栏才能回来。 */
   async recoverDesktopWindow(): Promise<void> {
     if (!this.desktopAbilityCtx) {
       hilog.warn(DOMAIN, TAG, '[MW] recoverDesktopWindow: no desktop ctx');
@@ -1143,7 +1167,7 @@ export class WineWindowManager {
     try {
       const win = await window.getLastWindow(this.desktopAbilityCtx);
       if (win) {
-        await win.recover();
+        await this.exitImmersiveFullscreen(win, true, 0);
         AppStorage.setOrCreate('vdImmersive', false);
         hilog.info(DOMAIN, TAG, '[MW] recoverDesktopWindow OK');
       }
@@ -1161,6 +1185,7 @@ export class WineWindowManager {
     try {
       const win = await window.getLastWindow(this.desktopAbilityCtx);
       if (win) {
+        await this.exitImmersiveFullscreen(win, false, 0);
         const d = display.getDefaultDisplaySync();
         const w = Math.max(640, Math.round(d.width * 0.9));
         const h = Math.max(480, Math.round(d.height * 0.9));
@@ -1212,6 +1237,21 @@ export class WineWindowManager {
     this.desktopLauncherVisible = visible;
     hilog.info(DOMAIN, TAG, '[MW] setDesktopLauncherVisible=%{public}s',
       visible ? 'true' : 'false');
+  }
+
+  setFloatingLayoutAnimating(animating: boolean): void {
+    this.floatingLayoutAnimating = animating;
+    hilog.info(DOMAIN, TAG, '[MW] setFloatingLayoutAnimating=%{public}s',
+      animating ? 'true' : 'false');
+  }
+
+  private shouldNotifyDesktopToplevelResize(forceToplevelResize: boolean): boolean {
+    if (forceToplevelResize) return true;
+    if (AppSettingsStore.getInstance().getGlobalSettings().desktopWindowMode !==
+      DesktopWindowMode.FLOATING) {
+      return true;
+    }
+    return false;
   }
 
   registerDesktopAbility(ctx: common.UIAbilityContext): void {

--- a/entry/src/main/ets/service/WineWindowManager.ets
+++ b/entry/src/main/ets/service/WineWindowManager.ets
@@ -747,6 +747,32 @@ export class WineWindowManager {
     }
   }
 
+  /**
+   * PC 沉浸全屏: 铺满屏幕并禁用顶/底边 hover 标题栏、关闭条和 Dock。
+   * 默认无参 maximize() 是 ENTER_IMMERSIVE, 会弹出关闭条抢走边缘鼠标。
+   */
+  enterImmersiveFullscreen(win: window.Window, logId: number = 0): void {
+    const label = logId > 0 ? '#' + logId.toString() : 'desktop';
+    try {
+      hilog.info(DOMAIN, TAG, '[MW] fullscreen %{public}s → DISABLE_TITLE_AND_DOCK_HOVER', label);
+      win.maximize(window.MaximizePresentation.ENTER_IMMERSIVE_DISABLE_TITLE_AND_DOCK_HOVER).then(() => {
+        hilog.info(DOMAIN, TAG, '[MW] fullscreen %{public}s OK (DISABLE_HOVER)', label);
+      }).catch((err: Error) => {
+        hilog.warn(DOMAIN, TAG, '[MW] fullscreen %{public}s DISABLE_HOVER failed, fallback: %{public}s',
+          label, JSON.stringify(err));
+        win.maximize().then(() => {
+          hilog.info(DOMAIN, TAG, '[MW] fullscreen %{public}s OK (ENTER_IMMERSIVE fallback)', label);
+        }).catch((fallbackErr: Error) => {
+          hilog.warn(DOMAIN, TAG, '[MW] fullscreen %{public}s fallback failed: %{public}s',
+            label, JSON.stringify(fallbackErr));
+        });
+      });
+    } catch (err) {
+      hilog.warn(DOMAIN, TAG, '[MW] fullscreen %{public}s exception: %{public}s',
+        label, JSON.stringify(err));
+    }
+  }
+
   // -- apply 单个事件到 window.Window --
   private applyEvent(toplevelId: number, event: string, data: string): void {
     const win = this.windows.get(toplevelId);
@@ -857,19 +883,10 @@ export class WineWindowManager {
         break;
       case 'fullscreen':
         // PC 模式游戏 xdg fullscreen: OHOS 沉浸式全屏 (铺满屏幕、盖住 dock)。
-        // 与 maximize 的 EXIT_IMMERSIVE (工作区最大化) 区分 — 游戏全屏是
-        // 真正的全屏; win.maximize() 不带参数默认 ENTER_IMMERSIVE。
-        // 画面由 popup (全屏拉伸) 承载, 主窗口沉浸式保证无系统 UI 露出。
-        try {
-          hilog.info(DOMAIN, TAG, '[MW] fullscreen #%{public}d → win.maximize() (ENTER_IMMERSIVE)', toplevelId);
-          win.maximize().then(() => {
-            hilog.info(DOMAIN, TAG, '[MW] fullscreen OK #%{public}d', toplevelId);
-          }).catch((err: Error) => {
-            hilog.warn(DOMAIN, TAG, '[MW] fullscreen #%{public}d failed: %{public}s', toplevelId, JSON.stringify(err));
-          });
-        } catch (err) {
-          hilog.warn(DOMAIN, TAG, '[MW] fullscreen #%{public}d exception: %{public}s', toplevelId, JSON.stringify(err));
-        }
+        // ENTER_IMMERSIVE_DISABLE_TITLE_AND_DOCK_HOVER (API 14+): 进入沉浸
+        // 全屏且鼠标悬停屏幕边缘热区时不唤出标题栏/关闭条/Dock — 默认
+        // ENTER_IMMERSIVE 会 hover 弹出关闭条, 抢走游戏边缘鼠标事件。
+        this.enterImmersiveFullscreen(win, toplevelId);
         break;
       case 'unfullscreen':
         // 退出沉浸式全屏, 恢复普通窗口; 尺寸由 C++ 侧 configure(preFs)

--- a/entry/src/main/resources/base/media/virtual_mouse_arrow.svg
+++ b/entry/src/main/resources/base/media/virtual_mouse_arrow.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <!-- Windows/Winlator-style arrow. Hotspot is the tip at ~1px,1px. -->
+  <path d="M1.1 1.1 L1.1 23.4 L7.2 17.6 L11.6 28.2 L15.4 26.6 L10.9 15.9 L19.2 15.9 Z"
+        fill="#FFFFFF" stroke="#000000" stroke-width="1.35" stroke-linejoin="round"
+        stroke-linecap="round"/>
+</svg>

--- a/entry/src/test/LocalUnit.test.ets
+++ b/entry/src/test/LocalUnit.test.ets
@@ -9,6 +9,7 @@ import {
   DisplayMode,
   EngineState,
   LaunchKind,
+  ViewMode,
   WinePresentationMode,
   RightJoystickOutputMode,
   VirtualGamepadLayout,
@@ -173,6 +174,9 @@ export default function localUnitTest() {
       expect(settings.virtualMouseConfig.mouseSensitivity).assertEqual(100);
       expect(settings.virtualMouseConfig.doubleClickInterval).assertEqual(100);
       expect(settings.virtualMouseConfig.showCursor).assertTrue();
+      expect(settings.viewMode).assertEqual(ViewMode.GRID);
+      expect(ViewMode.FILES).assertEqual('files');
+      expect(settings.preserveUserDataOnReset).assertTrue();
     });
 
     it('clonesVirtualMouseSettingsWithoutSharingMutableState', 0, () => {


### PR DESCRIPTION
## Summary
- PC 沉浸全屏、文件浏览、箭头光标、Wine 重置与 Winlator 风格按键。
- 浮窗桌面缩小/放大可恢复；PC 沉浸全屏可还原系统标题栏。
- 蓝牙/实体键盘可打印键改由桌面 XComponent 接收，不点「键盘」也能打字母；宿主 IME 与屏幕虚拟键仍可用。

## Test plan
- [ ] 手机/平板：浮窗缩小再放大，桌面可点、布局不丢
- [ ] PC：进入沉浸全屏后能还原系统标题栏
- [ ] 文件浏览、箭头光标、Wine 重置按钮可用
- [ ] 蓝牙键盘：不点「键盘」可在桌面/记事本打字母，方向键仍可用
- [ ] 屏幕虚拟键 A/空格/回车仍进 Wine
- [ ] 点开宿主键盘：中文预上屏/上屏、ASCII、回车正常；关掉后蓝牙字母恢复
