### PR TITLE
fix(input): correct virtual joystick upper-octant WASD mapping

### DIFF
--- a/entry/src/main/ets/model/AppModels.ets
+++ b/entry/src/main/ets/model/AppModels.ets
@@ -512,8 +512,8 @@ export function resolveVirtualJoystickDirection(dx: number, dy: number, radius: 
   if (angle >= 67.5 && angle < 112.5) return { up: false, down: true, left: false, right: false };
   if (angle >= 112.5 && angle < 157.5) return { up: false, down: true, left: true, right: false };
   if (angle >= 157.5 || angle < -157.5) return { up: false, down: false, left: true, right: false };
-  if (angle >= -157.5 && angle < -112.5) return { up: true, down: false, left: false, right: false };
-  if (angle >= -112.5 && angle < -67.5) return { up: true, down: false, left: false, right: true };
+  if (angle >= -157.5 && angle < -112.5) return { up: true, down: false, left: true, right: false };
+  if (angle >= -112.5 && angle < -67.5) return { up: true, down: false, left: false, right: false };
   return { up: true, down: false, left: false, right: true };
 }
 

--- a/entry/src/test/LocalUnit.test.ets
+++ b/entry/src/test/LocalUnit.test.ets
@@ -206,6 +206,16 @@ export default function localUnitTest() {
       expect(diagonal.up).assertTrue();
       expect(diagonal.right).assertTrue();
       expect(diagonal.down || diagonal.left).assertFalse();
+      const upLeft = resolveVirtualJoystickDirection(-70, -70, 100, 15, true);
+      expect(upLeft.up).assertTrue();
+      expect(upLeft.left).assertTrue();
+      expect(upLeft.down || upLeft.right).assertFalse();
+      const up = resolveVirtualJoystickDirection(0, -70, 100, 15, true);
+      expect(up.up).assertTrue();
+      expect(up.down || up.left || up.right).assertFalse();
+      const left = resolveVirtualJoystickDirection(-70, 0, 100, 15, true);
+      expect(left.left).assertTrue();
+      expect(left.up || left.down || left.right).assertFalse();
       const fourWay = resolveVirtualJoystickDirection(70, -25, 100, 15, false);
       expect(fourWay.right).assertTrue();
       expect(fourWay.up).assertFalse();


### PR DESCRIPTION
## Summary
- Fix `resolveVirtualJoystickDirection` upper-left / upper octants so WASD keys match stick angle (was mapping up-left as up-only and up as up-right).
- Add LocalUnit coverage for up-left, up, and left directions.

## Test plan
- [ ] Run LocalUnit tests covering `resolveVirtualJoystickDirection`
- [ ] On device/emulator, hold virtual stick in up, up-left, and left and confirm WASD keys match