### PR TITLE
fix(input): STICK 八向象限 + Winlator 鼠标键图标

### DIFF
--- a/entry/src/main/ets/components/VirtualInputOverlay.ets
+++ b/entry/src/main/ets/components/VirtualInputOverlay.ets
@@ -6,6 +6,8 @@ import {
   InputBinding,
   InputBindingKind,
   InputProfile,
+  MOUSE_LEFT_BUTTON,
+  MOUSE_RIGHT_BUTTON,
   createDefaultInputProfile,
   resolveVirtualJoystickDirection
 } from '../model/AppModels';
@@ -1378,12 +1380,32 @@ export struct VirtualInputOverlay {
       .id('virtual-element-' + element.id)
   }
 
+  private isMouseButtonElement(element: ControlElement): boolean {
+    const binding = (element.bindings ?? [])[0];
+    return binding !== undefined && binding.kind === InputBindingKind.MOUSE &&
+      (binding.code === MOUSE_LEFT_BUTTON || binding.code === MOUSE_RIGHT_BUTTON);
+  }
+
+  @Builder
+  private MouseButtonIcon(element: ControlElement) {
+    Image((element.bindings ?? [])[0].code === MOUSE_LEFT_BUTTON ?
+      $r('app.media.virtual_mouse_left') : $r('app.media.virtual_mouse_right'))
+      .width(Math.min(this.elementWidth(element), this.elementHeight(element)) * 0.58)
+      .height(Math.min(this.elementWidth(element), this.elementHeight(element)) * 0.58)
+      .objectFit(ImageFit.Contain)
+      .fillColor(this.winlatorTextColor(this.isElementPressed(element.id)))
+  }
+
   @Builder
   private ButtonElement(element: ControlElement) {
     Stack({ alignContent: Alignment.Center }) {
-      Text(element.text.length > 0 ? element.text : '键')
-        .fontSize(this.buttonLabelFontSize(element)).fontWeight(FontWeight.Medium).maxLines(1)
-        .fontColor(this.winlatorTextColor(this.isElementPressed(element.id)))
+      if (this.isMouseButtonElement(element)) {
+        this.MouseButtonIcon(element)
+      } else {
+        Text(element.text.length > 0 ? element.text : '键')
+          .fontSize(this.buttonLabelFontSize(element)).fontWeight(FontWeight.Medium).maxLines(1)
+          .fontColor(this.winlatorTextColor(this.isElementPressed(element.id)))
+      }
     }
     .width(this.elementWidth(element)).height(this.elementHeight(element))
     .borderRadius(this.elementRadius(element))

--- a/entry/src/main/ets/model/AppModels.ets
+++ b/entry/src/main/ets/model/AppModels.ets
@@ -512,8 +512,8 @@ export function resolveVirtualJoystickDirection(dx: number, dy: number, radius: 
   if (angle >= 67.5 && angle < 112.5) return { up: false, down: true, left: false, right: false };
   if (angle >= 112.5 && angle < 157.5) return { up: false, down: true, left: true, right: false };
   if (angle >= 157.5 || angle < -157.5) return { up: false, down: false, left: true, right: false };
-  if (angle >= -157.5 && angle < -112.5) return { up: true, down: false, left: false, right: false };
-  if (angle >= -112.5 && angle < -67.5) return { up: true, down: false, left: false, right: true };
+  if (angle >= -157.5 && angle < -112.5) return { up: true, down: false, left: true, right: false };
+  if (angle >= -112.5 && angle < -67.5) return { up: true, down: false, left: false, right: false };
   return { up: true, down: false, left: false, right: true };
 }
 
@@ -711,9 +711,9 @@ function defaultTemplateElements(): ControlElement[] {
     createControlElement(ControlElementType.D_PAD, 0.12, 0.70, '', dpadWASD()),
     createControlElement(ControlElementType.TRACKPAD, 0.68, 0.76, '视角', []),
     createControlElement(ControlElementType.BUTTON, 0.86, 0.62, '空格', [keyBinding(57)]),
-    createControlElement(ControlElementType.BUTTON, 0.94, 0.62, '左键', [mouseBinding(MOUSE_LEFT_BUTTON)]),
+    createControlElement(ControlElementType.BUTTON, 0.94, 0.62, '', [mouseBinding(MOUSE_LEFT_BUTTON)]),
     createControlElement(ControlElementType.BUTTON, 0.86, 0.84, 'E', [keyBinding(18)]),
-    createControlElement(ControlElementType.BUTTON, 0.94, 0.84, '右键', [mouseBinding(MOUSE_RIGHT_BUTTON)]),
+    createControlElement(ControlElementType.BUTTON, 0.94, 0.84, '', [mouseBinding(MOUSE_RIGHT_BUTTON)]),
     createControlElement(ControlElementType.BUTTON, 0.06, 0.16, 'Esc', [keyBinding(1)], ControlElementShape.ROUND_RECT, 0.72),
     createControlElement(ControlElementType.BUTTON, 0.14, 0.16, 'Shift', [keyBinding(42)], ControlElementShape.ROUND_RECT, 0.72, true),
     createControlElement(ControlElementType.BUTTON, 0.22, 0.16, 'Ctrl', [keyBinding(29)], ControlElementShape.ROUND_RECT, 0.72, true)

--- a/entry/src/main/resources/base/media/virtual_mouse_left.svg
+++ b/entry/src/main/resources/base/media/virtual_mouse_left.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <!-- Winlator-style top-down mouse, left button highlighted -->
+  <path d="M16 4.5 C10.8 4.5 7 8.2 7 13.2 V18.2 C7 22.2 10.2 26 16 26 C21.8 26 25 22.2 25 18.2 V13.2 C25 8.2 21.2 4.5 16 4.5 Z"
+        fill="none" stroke="#FFFFFF" stroke-width="1.35" stroke-linejoin="round"/>
+  <path d="M16 8.5 V21.5" stroke="#FFFFFF" stroke-width="1.1" stroke-linecap="round"/>
+  <path d="M16 8.5 C12.6 8.5 10.2 10.4 10.2 13.2 V16.2 C10.2 18.2 11.8 19.8 16 19.8 V8.5 Z"
+        fill="#FFFFFF"/>
+</svg>

--- a/entry/src/main/resources/base/media/virtual_mouse_right.svg
+++ b/entry/src/main/resources/base/media/virtual_mouse_right.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <!-- Winlator-style top-down mouse, right button highlighted -->
+  <path d="M16 4.5 C10.8 4.5 7 8.2 7 13.2 V18.2 C7 22.2 10.2 26 16 26 C21.8 26 25 22.2 25 18.2 V13.2 C25 8.2 21.2 4.5 16 4.5 Z"
+        fill="none" stroke="#FFFFFF" stroke-width="1.35" stroke-linejoin="round"/>
+  <path d="M16 8.5 V21.5" stroke="#FFFFFF" stroke-width="1.1" stroke-linecap="round"/>
+  <path d="M16 8.5 C19.4 8.5 21.8 10.4 21.8 13.2 V16.2 C21.8 18.2 20.2 19.8 16 19.8 V8.5 Z"
+        fill="#FFFFFF"/>
+</svg>

--- a/entry/src/test/LocalUnit.test.ets
+++ b/entry/src/test/LocalUnit.test.ets
@@ -206,6 +206,16 @@ export default function localUnitTest() {
       expect(diagonal.up).assertTrue();
       expect(diagonal.right).assertTrue();
       expect(diagonal.down || diagonal.left).assertFalse();
+      const upLeft = resolveVirtualJoystickDirection(-70, -70, 100, 15, true);
+      expect(upLeft.up).assertTrue();
+      expect(upLeft.left).assertTrue();
+      expect(upLeft.down || upLeft.right).assertFalse();
+      const up = resolveVirtualJoystickDirection(0, -70, 100, 15, true);
+      expect(up.up).assertTrue();
+      expect(up.down || up.left || up.right).assertFalse();
+      const left = resolveVirtualJoystickDirection(-70, 0, 100, 15, true);
+      expect(left.left).assertTrue();
+      expect(left.up || left.down || left.right).assertFalse();
       const fourWay = resolveVirtualJoystickDirection(70, -25, 100, 15, false);
       expect(fourWay.right).assertTrue();
       expect(fourWay.up).assertFalse();


### PR DESCRIPTION
## Summary
- Fix STICK 8-way octant mapping：修正虚拟摇杆上半区八向象限，**左上不再误触 right/D**
- Show Winlator-style mouse icons：`MOUSE_LEFT` / `MOUSE_RIGHT` 按钮改用鼠标左右键图标（默认模板文案置空）
- 补充 stick direction 单元测试

## Test plan
- [ ] 虚拟摇杆拨向左上：应触发 W+A，不应出现 D
- [ ] 默认模板左右键显示图标而非「左键」「右键」文字
- [ ] 跑 LocalUnit stick direction 相关用例
