### PR TITLE
1.2.9: PC cursor hide + Box64 compat channel

### DIFF
--- a/AppScope/app.json5
+++ b/AppScope/app.json5
@@ -2,8 +2,8 @@
   "app": {
     "bundleName": "com.vintage.pomelopro",
     "vendor": "example",
-    "versionCode": 1002008,
-    "versionName": "1.2.8",
+    "versionCode": 1002009,
+    "versionName": "1.2.9",
     "icon": "$media:layered_image",
     "label": "$string:app_name"
   }

--- a/docs/UPSTREAM_SYNC_POINT.md
+++ b/docs/UPSTREAM_SYNC_POINT.md
@@ -3,17 +3,23 @@
 > 用途：标明本地产品线已合并到 WineHua 上游的哪个提交，避免重复合并/漏合并。
 > 本地镜像分支：`mirror_master`（跟踪 `winehua/master`，只读对照，不 push）。
 > 维护命令：`git fetch winehua && git branch -f mirror_master winehua/master`
-> 下次同步前先执行：`git log e16d79b..mirror_master --oneline`
+> 下次同步前先执行：`git log 90edaae..mirror_master --oneline`
 
 | 项 | 值 |
 | --- | --- |
 | 上游仓库 | `https://github.com/winehua/WineHua` |
 | 上游分支 | `master` |
-| **最后核对的上游 SHA** | `e16d79b`（2026-08-24，`mirror_master` 尖端） |
+| **最后核对的上游 SHA** | `90edaae`（2026-08-25，`mirror_master` 尖端） |
 | 功能同步起点（用户指定） | `10a9e6caf33e0147363793947461417dd60a8372`（master 线等价 `189c27c`） |
 | 合并方式 | 选择性 cherry-pick -x：只吸收输入/渲染功能，不上游品牌/版本号/CI/README |
 | 本地对应分支 | `feature/sync-winehua-10a9e6c`（合入 `main` 后以 main 为准） |
-| 核对日期 | 2026-08-24 |
+| 核对日期 | 2026-08-25 |
+
+## 已核对的上游增量（e16d79b..90edaae）
+
+从上一基线 `e16d79b` 到 `winehua/master` 尖端 `90edaae`。采纳 Box64 兼容档位 native 通道（`7cff882` `dcf3906` `90edaae`），跳过上游 `Box64Dynarec.ets` 与版本标签。
+
+明细见 `docs/private-upstream-sync.md`「2026-08-25 WineHua master 增量（e16d79b..90edaae）」。
 
 ## 已核对的上游增量（10a9e6c..e16d79b）
 

--- a/docs/private-upstream-sync.md
+++ b/docs/private-upstream-sync.md
@@ -4,7 +4,27 @@
 
 基线：WineHua `VintagePomeloMaster` @ `ba7218a`
 
-> **同步基线标记**：最新核对到的上游 SHA 见 [UPSTREAM_SYNC_POINT.md](UPSTREAM_SYNC_POINT.md)（当前为 WineHua `master` @ `e16d79b`，本地镜像 `mirror_master`）。下次同步先 `git fetch winehua && git branch -f mirror_master winehua/master && git log e16d79b..mirror_master --oneline`，避免重复合并。
+> **同步基线标记**：最新核对到的上游 SHA 见 [UPSTREAM_SYNC_POINT.md](UPSTREAM_SYNC_POINT.md)（当前为 WineHua `master` @ `90edaae`，本地镜像 `mirror_master`）。下次同步先 `git fetch winehua && git branch -f mirror_master winehua/master && git log 90edaae..mirror_master --oneline`，避免重复合并。
+
+### 2026-08-25 WineHua master 增量（e16d79b..90edaae）
+
+- 分支：`feature/sync-winehua-90edaae`（基于当前产品线 HEAD，含 PC 虚拟桌面光标隐藏门禁）。
+- 镜像：`mirror_master` 跟踪 `winehua/master` @ `90edaae`。
+- 原则：只吸收 Box64 兼容档位 native 通道；不引入上游 `Box64Dynarec.ets` / `WineEnvService` / 品牌 / 版本号 / CI / `dxvkBackend`+`wineLang` 第 9–10 参。
+- 已移植（上游 SHA → 本地适配，非整 commit cherry-pick）：
+
+  | 上游 SHA | 说明 |
+  | --- | --- |
+  | `7cff882` | `compatEnvStr` 通道：wineboot / wineserver / explorer 三路注入 |
+  | `dcf3906` | `FilterCompatLines`、automation 跳过、wineserver 二次只重放 `BOX64_DYNAREC_*`、napi 返回码校验 |
+  | `90edaae` | 注入调用点 `__aarch64__` 守卫 |
+
+- 私有适配：
+  - `launchClient` 本仓仍为 8 参 + 新增第 9 参 `compatEnvStr`（不上游 11 参）
+  - 档位表继续用 `resolveBox64PresetEnv`（不含 WEAKBARRIER / VOLATILE_METADATA）
+  - `WineEngineService.ensureReady` 把全局 `box64Preset` 编成分号串下发
+- 跳过：WineHua `Box64Dynarec.ets`（当时尚未接到设置页，且引用上游 service 名）；`rc-1.0.15` / `rc-1.0.16` 标签；`winehua/main-ui`。
+- 子模块 gitlink：未跟随上游。
 
 ### 2026-08-24 WineHua master 增量（10a9e6c..e16d79b）
 

--- a/entry/src/main/cpp/napi_init.cpp
+++ b/entry/src/main/cpp/napi_init.cpp
@@ -272,8 +272,8 @@ static napi_value SetHostShadowProfile(napi_env env, napi_callback_info info) {
 }
 
 static napi_value LaunchClient(napi_env env, napi_callback_info info) {
-    size_t argc = 8;
-    napi_value args[8] = {};
+    size_t argc = 9;
+    napi_value args[9] = {};
     napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
 
     auto* p = new LaunchParams();
@@ -302,6 +302,16 @@ static napi_value LaunchClient(napi_env env, napi_callback_info info) {
         if (!strcmp(d3dBackend, "wined3d") || !strncmp(d3dBackend, "dxvk_", 5))
             p->d3dBackend = d3dBackend;
     }
+    if (argc >= 9) {
+        char compatEnv[2048] = {};
+        napi_status compatStatus =
+            napi_get_value_string_utf8(env, args[8], compatEnv, sizeof(compatEnv), nullptr);
+        if (compatStatus != napi_ok) {
+            OH_LOG_WARN(LOG_APP, "[Launch] compatEnvStr arg is not a string, ignored");
+        } else {
+            p->compatEnvStr = compatEnv;
+        }
+    }
     // 向后兼容: 旧调用未传 homeDir 时使用默认路径
     if (p->homeDir.empty()) {
         p->homeDir = "/storage/Users/currentUser/Download";
@@ -311,7 +321,8 @@ static napi_value LaunchClient(napi_env env, napi_callback_info info) {
                 "[Launch] exe=%{public}s sock=%{public}s lib=%{public}s home=%{public}s prefix=%{public}s automation=%{public}s (async)",
                 p->exePath.c_str(), p->sockPath.c_str(), p->libPath.c_str(), p->homeDir.c_str(),
                 p->prefixDir.c_str(), p->automationMode ? "true" : "false");
-    OH_LOG_INFO(LOG_APP, "[Launch] desktop D3D backend=%{public}s", p->d3dBackend.c_str());
+    OH_LOG_INFO(LOG_APP, "[Launch] desktop D3D backend=%{public}s compat=%{public}s",
+                p->d3dBackend.c_str(), p->compatEnvStr.empty() ? "baseline" : "preset");
 
     // 保证可执行
     if (access(p->exePath.c_str(), X_OK) != 0) chmod(p->exePath.c_str(), 0755);

--- a/entry/src/main/cpp/types/libentry/Index.d.ts
+++ b/entry/src/main/cpp/types/libentry/Index.d.ts
@@ -1,7 +1,8 @@
 export const startServer: (sockPath: string) => boolean;
 export const setHostShadowProfile: (profile: string) => boolean;
 export const launchClient: (exePath: string, argv: string[], sockPath: string, libPath: string,
-  homeDir: string, automationMode?: boolean, prefixMode?: string, d3dBackend?: string) => number;
+  homeDir: string, automationMode?: boolean, prefixMode?: string, d3dBackend?: string,
+  compatEnvStr?: string) => number;
 export const stopClient: () => void;
 export const stopAll: () => void;
 export const setStateCallback: (cb: (state: string) => void) => void;

--- a/entry/src/main/cpp/wine_child.cpp
+++ b/entry/src/main/cpp/wine_child.cpp
@@ -331,7 +331,7 @@ static void apply_entry_param_env_overrides(const std::vector<std::string>& envO
         std::string key = envLine.substr(0, sep);
         std::string value = envLine.substr(sep + 1);
         setenv(key.c_str(), value.c_str(), 1);
-        if (key == "WINEHUA_BOOTSTRAP_PHASE")
+        if (key == "WINEHUA_BOOTSTRAP_PHASE" || key.rfind("BOX64_DYNAREC_", 0) == 0)
             OH_LOG_INFO(LOG_APP, "[WineChild] env override %{public}s=%{public}s",
                         key.c_str(), value.c_str());
     }
@@ -754,6 +754,16 @@ extern "C" void WineserverMain(NativeChildProcess_Args args)
     std::string libDir = std::string(binDir) + "/x86_64-unix";
     setenv("BOX64_LD_LIBRARY_PATH", libDir.c_str(), 1);
     SetBox64PerfEnv();
+    // __env= 段在此前已 apply 一次 (WINEPREFIX 等依赖 mkdir 前覆盖)。
+    // SetBox64PerfEnv 会把 BOX64_DYNAREC_* 盖回硬基线, 此处只重放 dynarec 行。
+    for (const std::string& envLine : envOverrides) {
+        if (envLine.rfind("BOX64_DYNAREC_", 0) != 0)
+            continue;
+        size_t sep = envLine.find('=');
+        if (sep == std::string::npos || sep == 0)
+            continue;
+        setenv(envLine.substr(0, sep).c_str(), envLine.substr(sep + 1).c_str(), 1);
+    }
 
     // Build argv: ["box64", "/path/to/wineserver", "wineserver", "-f", "-p"]
     std::string wsPath = std::string(binDir) + "/wineserver";

--- a/entry/src/main/cpp/wine_launch.cpp
+++ b/entry/src/main/cpp/wine_launch.cpp
@@ -430,6 +430,56 @@ static void EmitEngineFail(const char* reason)
     EmitEngineEvent(event.c_str());
 }
 
+// -- 兼容模式全局档位 (设置页 → launchClient 第 9 参 compatEnvStr 分号串) --
+// 对齐 WineHua 7cff882/dcf3906/90edaae: ArkTS 拼 "K=V;K=V;...", native 零表
+// 只放行 BOX64_DYNAREC_* (防注入其它 key)。空串 = 出厂基线不注入。
+// 仅 __aarch64__ (Box64) 有意义; x86_64 原生空转。
+#ifdef __aarch64__
+static std::vector<std::string> FilterCompatLines(const std::string& compatEnvStr)
+{
+    std::vector<std::string> raw;
+    std::string cur;
+    for (const char c : compatEnvStr) {
+        if (c == ';') {
+            if (!cur.empty()) raw.push_back(cur);
+            cur.clear();
+        } else {
+            cur += c;
+        }
+    }
+    if (!cur.empty()) raw.push_back(cur);
+    std::vector<std::string> filtered;
+    for (const std::string& line : raw) {
+        if (line.rfind("BOX64_DYNAREC_", 0) != 0)
+            continue;
+        if (line.find('|') != std::string::npos || line.find('\n') != std::string::npos)
+            continue;
+        if (line.find('=') == std::string::npos)
+            continue;
+        filtered.push_back(line);
+    }
+    return filtered;
+}
+
+static void AppendCompatEnvLines(std::vector<std::string>& envStrs, const LaunchParams& p)
+{
+    if (p.automationMode)
+        return;
+    for (const std::string& line : FilterCompatLines(p.compatEnvStr))
+        UpsertEnvLine(envStrs, line);
+}
+
+static void AppendCompatEnvToEntryParams(std::string& entryParams, const LaunchParams& p)
+{
+    if (p.automationMode)
+        return;
+    for (const std::string& line : FilterCompatLines(p.compatEnvStr)) {
+        entryParams += "|__env=";
+        entryParams += line;
+    }
+}
+#endif // __aarch64__
+
 static bool LaunchPadMode(LaunchParams* p, int audioBootstrapFd,
                           const std::string& serializedEnv) {
     // 通过 fdList 传递 audio bootstrap fd (仅 explorer 需要音频)
@@ -470,6 +520,9 @@ static bool LaunchPadMode(LaunchParams* p, int audioBootstrapFd,
     int32_t wsChildPid = -1;
     {
         std::string wsEntryParams = p->homeDir + "|" + p->winehuaBin + "|wineserver|-f|-p";
+#ifdef __aarch64__
+        AppendCompatEnvToEntryParams(wsEntryParams, *p);
+#endif
         OH_LOG_INFO(LOG_APP, "[Launch-Async] wineserver args=%{public}s", wsEntryParams.c_str());
         NativeChildProcess_Args wsArgs = {};
         wsArgs.entryParams = const_cast<char*>(wsEntryParams.c_str());
@@ -542,6 +595,9 @@ static bool LaunchPadMode(LaunchParams* p, int audioBootstrapFd,
 #else
             std::string entryParams = p->homeDir + "|" + p->winehuaBin + "|" + desktopTag +
                 "wine|wineboot|--init|__env=WINEPREFIX=" + p->prefixDir;
+#endif
+#ifdef __aarch64__
+            AppendCompatEnvToEntryParams(entryParams, *p);
 #endif
             NativeChildProcess_Args childArgs = {};
             childArgs.entryParams = const_cast<char*>(entryParams.c_str());
@@ -671,6 +727,9 @@ static bool LaunchPadMode(LaunchParams* p, int audioBootstrapFd,
         OH_LOG_INFO(LOG_APP, "[Launch-Async] prefix ready; seeding wineboot boot event (--init)...");
         std::string entryParams = p->homeDir + "|" + p->winehuaBin + "|" +
             "wine|wineboot|--init|__env=WINEPREFIX=" + p->prefixDir;
+#ifdef __aarch64__
+        AppendCompatEnvToEntryParams(entryParams, *p);
+#endif
         NativeChildProcess_Args childArgs = {};
         childArgs.entryParams = const_cast<char*>(entryParams.c_str());
         NativeChildProcess_Options options = {};
@@ -841,6 +900,9 @@ void LaunchThreadFunc(LaunchParams* p) {
     p->envStrs = BuildWineEnv(p->sockDir, p->sockName, p->libPath, p->winehuaBin,
                                audioBootstrapFd, p->homeDir, p->prefixDir);
     AppendD3dBackendEnv(p->envStrs, p->d3dBackend, p->winehuaBin);
+#ifdef __aarch64__
+    AppendCompatEnvLines(p->envStrs, *p);
+#endif
     const std::string serializedEnv = SerializeEnvToEntryParams(p->envStrs);
 
     mkdir(p->prefixDir.c_str(), 0755);

--- a/entry/src/main/cpp/wine_launch.h
+++ b/entry/src/main/cpp/wine_launch.h
@@ -14,6 +14,9 @@ struct LaunchParams {
     std::string winehuaBin;
     std::string prefixDir;
     std::string d3dBackend = "dxvk_legacy";
+    // Box64 dynarec 全局档位 ("K=V;K=V;..."), 来自设置页兼容预设; 空 = 出厂基线。
+    // native 只放行 BOX64_DYNAREC_* 行, 经 wineboot/wineserver __env= 与会话 env 注入。
+    std::string compatEnvStr;
     bool automationMode = false;
     std::vector<std::string> envStrs;
     std::vector<char*> envp;

--- a/entry/src/main/ets/model/AppModels.ets
+++ b/entry/src/main/ets/model/AppModels.ets
@@ -240,6 +240,11 @@ export function resolveBox64PresetEnv(presetId: string): string[] {
   }
 }
 
+/** 全局预设 → native launchClient compatEnvStr (分号串); 默认档为空。 */
+export function box64PresetEnvString(presetId: string): string {
+  return resolveBox64PresetEnv(presetId).join(';');
+}
+
 /**
  * Unity 兼容档额外追加的启动参数。参考 Winlator：Unity 引擎游戏在
  * Stability 预设之外还需要 -force-gfx-direct，让 Unity 跳过 GDI 间接

--- a/entry/src/main/ets/service/WineEngineService.ets
+++ b/entry/src/main/ets/service/WineEngineService.ets
@@ -13,7 +13,8 @@ import {
   WinePresentationMode,
   canTransitionEngineState,
   LaunchKind,
-  resolveWinePresentationMode
+  resolveWinePresentationMode,
+  box64PresetEnvString
 } from '../model/AppModels';
 import { AppSettingsStore } from './AppSettingsStore';
 import { syncManagedSmoke } from './SmokeRunner';
@@ -453,7 +454,8 @@ export class WineEngineService {
       // Native runs wineboot --init only for a new prefix. Existing prefixes
       // are migrated above before any wineserver process starts.
       testNapi.launchClient(BOX64, [], SOCK, WINE_BIN + ':' + WINE_LIB,
-        homeDirectory, false, '', this.d3dBackend);
+        homeDirectory, false, '', this.d3dBackend,
+        box64PresetEnvString(AppSettingsStore.getInstance().getGlobalSettings().box64Preset));
       return this.waitForReady();
     } catch (error) {
       hilog.error(DOMAIN, TAG, 'ensureReady failed: %{public}s', JSON.stringify(error));

--- a/entry/src/main/ets/service/WineWindowManager.ets
+++ b/entry/src/main/ets/service/WineWindowManager.ets
@@ -1303,14 +1303,21 @@ export class WineWindowManager {
   //   融合模式   → 允许 (每个 app 独立窗口, setPointerVisible 按"当前窗口"
   //                作用, 只有发起相对模式的应用窗口隐藏, 天然满足"其它窗口
   //                不隐藏") — 不拦。
-  //   桌面模式   → 悬浮窗形态禁止; 完整桌面形态仅"非桌面 root surface"允许。
-  //                Pad: 悬浮 = launcherVisible; 完整 = !launcherVisible
-  //               完整桌面下 fromToplevel == desktopRootId → 桌面 shell 自身藏
-  //               光标 (启动瞬时) → 禁止; 子窗口 (真实游戏/程序) → 允许。
+  //   PC 虚拟桌面 → 对齐 WineHua desktopSeparateWindow + desktopWindowActive:
+  //                DesktopAbility 前台才允许; 不看 Pad 浮窗标志
+  //                (desktopLauncherVisible 默认 true, PC 从不走 Index 放大清位)。
+  //   Pad/手机    → 悬浮窗形态禁止; 完整桌面形态仅非桌面 root 允许。
+  //                悬浮 = launcherVisible; 完整 = !launcherVisible
+  //   完整桌面下 fromToplevel == desktopRootId → 桌面 shell 自身藏
+  //   光标 (启动瞬时) → 禁止; 子窗口 (真实游戏/程序) → 允许。
   private canHideCursor(fromToplevel: number): boolean {
     if (!this.isDesktopMode) return true;
-    if (this.desktopLauncherVisible) return false;
-    if (this.desktopAbilityRunning && !this.desktopAbilityForeground) return false;
+    if (DeviceCapabilityPolicy.usesManagedWineWindows()) {
+      if (!this.desktopAbilityForeground) return false;
+    } else {
+      if (this.desktopLauncherVisible) return false;
+      if (this.desktopAbilityRunning && !this.desktopAbilityForeground) return false;
+    }
     return fromToplevel !== this.desktopRootId;
   }
 
@@ -1319,11 +1326,13 @@ export class WineWindowManager {
     const canHide = this.canHideCursor(this.pointerLockToplevel);
     const shouldHide = this.pointerLocked && canHide;
     hilog.info(DOMAIN, TAG,
-      '[MW]PtrVis → %{public}s (locked=%{public}s canHide=%{public}s tl=%{public}d mode=%{public}s launcher=%{public}s fg=%{public}s)',
+      '[MW]PtrVis → %{public}s (locked=%{public}s canHide=%{public}s tl=%{public}d desktop=%{public}s pcManaged=%{public}s launcher=%{public}s fg=%{public}s root=%{public}d)',
       shouldHide ? 'HIDE' : 'SHOW',
       String(this.pointerLocked), String(canHide), this.pointerLockToplevel,
-      String(this.isDesktopMode), String(this.desktopLauncherVisible),
-      String(this.desktopAbilityForeground));
+      String(this.isDesktopMode),
+      String(DeviceCapabilityPolicy.usesManagedWineWindows()),
+      String(this.desktopLauncherVisible),
+      String(this.desktopAbilityForeground), this.desktopRootId);
     if (shouldHide === this.effectiveHidden) return;
     this.effectiveHidden = shouldHide;
     pointer.setPointerVisible(!shouldHide).catch((e: BusinessError) => {


### PR DESCRIPTION
## Summary
- Restore PC virtual-desktop system-cursor hide (`canHideCursor` gates on DesktopAbility foreground, not Pad `desktopLauncherVisible`).
- Absorb WineHua `master` box64 compat env channel (`7cff882`/`dcf3906`/`90edaae`) as `launchClient` 9th arg; reuse private `resolveBox64PresetEnv`.
- Bump product version to **1.2.9** (`1002009`).

## Test plan
- [x] `make test` in `winehua-dev`: geometry 52 + blit_scaled 402, 0 failures
- [x] `scripts/vpbuild.sh make NATIVE_ARCH=arm64-v8a hap`: BUILD SUCCESSFUL, debug-signed HAP `entry/build/default/outputs/default/entry-default-signed.hap` (2026-08-25)
- [ ] PC VIRTUAL: fullscreen relative-mode game shows hilog `[MW]PtrVis ? HIDE` (`canHide=true`, `pcManaged=true`, `fg=true`, `tl != root`)
- [ ] Desktop shell / Pad floating window still `SHOW`
- [ ] ARM64: global Box64 preset reaches wineserver/wineboot/explorer (`compat=preset` in launch log); x86_64 path unchanged